### PR TITLE
delete_selected key error exception fix

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -445,7 +445,8 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
 
     def get_actions(self, request):
         actions = super(FolderAdmin, self).get_actions(request)
-        del actions['delete_selected']
+        if 'delete_selected' in actions:
+					del actions['delete_selected']
         return actions
 
     def move_to_clipboard(self, request, files_queryset, folders_queryset):


### PR DESCRIPTION
Fixed a bug that causes a key error exception when using the popup selector for Folder in the Folder Permission admin

Also, the code now looks more like this: https://docs.djangoproject.com/en/dev/ref/contrib/admin/actions/#conditionally-enabling-or-disabling-actions
