### PR TITLE
change import order for Python Imaging Library

### DIFF
--- a/filer/thumbnail_processors.py
+++ b/filer/thumbnail_processors.py
@@ -1,12 +1,12 @@
 #-*- coding: utf-8 -*-
 import re
 try:
-    import Image
-    import ImageDraw
+    from PIL import Image
+    from PIL import ImageDraw
 except ImportError:
     try:
-        from PIL import Image
-        from PIL import ImageDraw
+        import Image
+        import ImageDraw
     except ImportError:
         raise ImportError("The Python Imaging Library was not found.")
 from easy_thumbnails import processors

--- a/filer/utils/pil_exif.py
+++ b/filer/utils/pil_exif.py
@@ -1,11 +1,11 @@
 #-*- coding: utf-8 -*-
 try:
-    import Image
-    import ExifTags
+    from PIL import Image
+    from PIL import ExifTags
 except ImportError:
     try:
-        from PIL import Image
-        from PIL import ExifTags
+        import Image
+        import ExifTags
     except ImportError:
         raise ImportError("The Python Imaging Library was not found.")
 

--- a/tests/buildout.cfg
+++ b/tests/buildout.cfg
@@ -19,7 +19,7 @@ eggs =
 extra-paths = ${buildout:directory}
 
 [versions]
-coverage = 3.4
+coverage = 3.5.1
 unittest-xml-reporting = 1.0.3
 
 [django]


### PR DESCRIPTION
Changing the import order for 'Image', etc. such that 'from PIL import
Image' is tried first. This allows to use a drop in replacement for PIL
like Pillow (which is setuptools compatible)

When running the tests, the version of coverage was not longer found. ->
bumped the coverage version to 3.5.1

The problem solved is the following:
on a production machine, a really old PIL is installed. When just doing the 'import Image', the old PILs version is used and not the current one, that comes with pillow.
