### PR TITLE
Temporary fix for easy_thumbnails 1.0 compat

### DIFF
--- a/filer/utils/filer_easy_thumbnails.py
+++ b/filer/utils/filer_easy_thumbnails.py
@@ -22,9 +22,17 @@ class ThumbnailerNameMixin(object):
     thumbnail_basedir = ''
     thumbnail_subdir = ''
     thumbnail_prefix = ''
-    thumbnail_quality = Thumbnailer.thumbnail_quality
-    thumbnail_extension = Thumbnailer.thumbnail_extension
-    thumbnail_transparency_extension = Thumbnailer.thumbnail_transparency_extension
+    thumbnail_quality = ''
+    thumbnail_extension = ''
+    thumbnail_transparency_extension = ''
+
+    def __init__(self, *args, **kwargs):
+        """
+        Attributes must be initialized at runtime, following easy_thumbnails 1.0 modifications
+        """
+        self.thumbnail_quality = self.thumbnail_quality
+        self.thumbnail_extension = self.thumbnail_extension
+        self.thumbnail_transparency_extension = self.thumbnail_transparency_extension
 
     def get_thumbnail_name(self, thumbnail_options, transparent=False):
         """
@@ -65,9 +73,17 @@ class ActionThumbnailerMixin(object):
     thumbnail_basedir = ''
     thumbnail_subdir = ''
     thumbnail_prefix = ''
-    thumbnail_quality = Thumbnailer.thumbnail_quality
-    thumbnail_extension = Thumbnailer.thumbnail_extension
-    thumbnail_transparency_extension = Thumbnailer.thumbnail_transparency_extension
+    thumbnail_quality = ''
+    thumbnail_extension = ''
+    thumbnail_transparency_extension = ''
+
+    def __init__(self, *args, **kwargs):
+        """
+        Attributes must be initialized at runtime, following easy_thumbnails 1.0 modifications
+        """
+        self.thumbnail_quality = self.thumbnail_quality
+        self.thumbnail_extension = self.thumbnail_extension
+        self.thumbnail_transparency_extension = self.thumbnail_transparency_extension
 
     def get_thumbnail_name(self, thumbnail_options, transparent=False):
         """


### PR DESCRIPTION
easy-thumbnails 1.0 moved some Thumbnailer object attributes definition to **init** method, so statically import them in mixins doesn't work anymore: see SmileyChris/easy-thumbnails@967d62a2e30e3c39a276f95af5a38669081e5985
