### PR TITLE
Added delete button for files in directory listing

### DIFF
--- a/filer/templates/admin/filer/folder/directory_table.html
+++ b/filer/templates/admin/filer/folder/directory_table.html
@@ -1,5 +1,7 @@
 {% load i18n %}
 {% load adminmedia admin_list filermedia filer_tags %}
+{% load url from future %}
+
 <div id="toolbartable">
     <table cellspacing="0">
         <thead>
@@ -35,6 +37,7 @@
                 <td><a href="{{ file.get_admin_url_path }}" title="{% blocktrans with file.label as item_label %}Change '{{ item_label }}' details{% endblocktrans %}"><img src="{% if file.icons.48 %}{{ file.icons.48 }}{% else %}{% filer_staticmedia_prefix %}icons/missingfile_48x48.png{% endif %}" alt="{{ file.default_alt_text }}" /></a></td>
                 <!-- Filename/Dimensions -->
                 <td>
+                    <a style="display: block; float: right;margin-left: 10px;" class="deletelink" href="{% url 'admin:filer_file_delete' file.pk %}" title="{% blocktrans with file.label as item_label %}Delete '{{ item_label }}'{% endblocktrans %}">{% trans "Delete" %}</a>
                     <a style="display: block; float: right;" class="changelink" href="{{ file.get_admin_url_path }}{% if is_popup %}?_popup=1{% endif %}" title="{% blocktrans with file.label as item_label %}Change '{{ item_label }}' details{% endblocktrans %}">{% trans "Change" %}</a>
                     <div><b><a href="{{ file.get_admin_url_path }}{% if is_popup %}?_popup=1{% endif %}" title="{% blocktrans with file.label as item_label %}Change '{{ item_label }}' details{% endblocktrans %}">{{ file.label }}</a></b><span class="tiny"> ({{ file.size|filesize:"auto1000long" }}{% ifequal file.file_type "Image" %}, {{ file.width }}x{{ file.height }} px{% endifequal %})</span></div>
                     <div>{% trans "Owner" %}: {{ file.owner|default:"n/a" }}</div>


### PR DESCRIPTION
Add a delete button in directory listing for files
We always call the FileAdmin.delete_view for simplicity sake.
A different approach would be to create a `get_admin_delete_url` like `get_admin_url_path` and call this on the object, but looks unnecessarily uglier.
