### PR TITLE
public/private typo in FILER_STORAGES example

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -40,7 +40,7 @@ A dictionary to configure storage backends used for file storage.
 e.g::
 
     FILER_STORAGES = {
-        'private': {
+        'public': {
             'main': {
                 'ENGINE': 'filer.storage.PublicFileSystemStorage',
                 'OPTIONS': {


### PR DESCRIPTION
This must be a bug in the docs, otherwise the example makes no sense :)
