### PR TITLE
Fix in docs: s/thumbnails/thumbnail/g

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -92,7 +92,7 @@ To enable automatic subject location aware cropping of images replace
 
 To crop an image and respect the subject location::
     
-    {% load thumbnails %}
+    {% load thumbnail %}
     {% thumbnail obj.img 200x300 crop upscale subject_location=obj.img.subject_location %}
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -64,7 +64,7 @@ templates
 ``FilerImageField`` can be used the same as a regular 
 `django.db.models.ImageField`_::
     
-    {% load thumbnails %}
+    {% load thumbnail %}
     {% thumbnail company.logo 250x250 crop %}
 
 admin


### PR DESCRIPTION
You mention `{% load thumbnails %}` in your docs. But that code snippet should be `{% load thumbnail %}` instead.
