### PR TITLE
fix #213: can't add folder permissions

### DIFF
--- a/filer/admin/__init__.py
+++ b/filer/admin/__init__.py
@@ -1,6 +1,5 @@
 #-*- coding: utf-8 -*-
 from django.contrib import admin
-from filer import settings
 from filer.admin.clipboardadmin import ClipboardAdmin
 from filer.admin.fileadmin import FileAdmin
 from filer.admin.folderadmin import FolderAdmin
@@ -8,9 +7,9 @@ from filer.admin.imageadmin import ImageAdmin
 from filer.admin.permissionadmin import PermissionAdmin
 from filer.models import FolderPermission, Folder, File, Clipboard, Image
 
-if settings.FILER_ENABLE_PERMISSIONS:
-    admin.site.register(FolderPermission, PermissionAdmin)
+
 admin.site.register(Folder, FolderAdmin)
 admin.site.register(File, FileAdmin)
 admin.site.register(Clipboard, ClipboardAdmin)
 admin.site.register(Image, ImageAdmin)
+admin.site.register(FolderPermission, PermissionAdmin)

--- a/filer/admin/permissionadmin.py
+++ b/filer/admin/permissionadmin.py
@@ -1,5 +1,7 @@
 #-*- coding: utf-8 -*-
+import inspect
 from django.contrib import admin
+from filer import settings
 from filer.fields import folder
 
 
@@ -17,5 +19,19 @@ class PermissionAdmin(admin.ModelAdmin):
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         db = kwargs.get('using')
         if db_field.name == 'folder':
-            kwargs['widget'] = folder.AdminFolderWidget(db_field.rel, using=db)
+            if 'admin_site' in inspect.getargspec(folder.AdminFolderWidget.__init__)[0]: # Django 1.4
+                widget_instance = folder.AdminFolderWidget(db_field.rel, self.admin_site, using=db)
+            else: # Django <= 1.3
+                widget_instance = folder.AdminFolderWidget(db_field.rel, using=db)
+            kwargs['widget'] = widget_instance
         return super(PermissionAdmin, self).formfield_for_foreignkey(db_field, request, **kwargs)
+
+    def get_model_perms(self, request):
+        # don't display the permissions admin if permissions are disabled.
+        # This method is easier for testing than not registering the admin at all at import time
+        enable_permissions = settings.FILER_ENABLE_PERMISSIONS
+        return {
+            'add': enable_permissions,
+            'change': enable_permissions,
+            'delete': enable_permissions,
+        }

--- a/filer/tests/admin.py
+++ b/filer/tests/admin.py
@@ -315,3 +315,19 @@ class FilerResizeOperationTests(BulkOperationsMixin, TestCase):
         self.image_obj = Image.objects.get(id=self.image_obj.id)
         self.assertEqual(self.image_obj.width, 42)
         self.assertEqual(self.image_obj.height, 42)
+
+
+class PermissionAdminTest(TestCase):
+    def setUp(self):
+        self.superuser = create_superuser()
+        self.client.login(username='admin', password='secret')
+
+    def tearDown(self):
+        self.client.logout()
+
+    def test_render_add_view(self):
+        """
+        Really stupid and simple test to see if the add Permission view can be rendered
+        """
+        response = self.client.get(reverse('admin:filer_folderpermission_add'))
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
- use django version specific init parameters for AdminFolderWidget 
- slight permission admin refactor to make tests possible
- added simple test that renders the permission add view
