### PR TITLE
nginx X-Accel-Redirect server backend needs no Content-Type header in django response

### DIFF
--- a/filer/server/backends/nginx.py
+++ b/filer/server/backends/nginx.py
@@ -22,6 +22,7 @@ class NginxXAccelRedirectServer(ServerBase):
         # we should not use get_mimetype() here, because it tries to access the file in the filesystem.
         #response = HttpResponse(mimetype=self.get_mimetype(file.path))
         response = HttpResponse()
+        del response['Content-Type']
         nginx_path = self.get_nginx_location(file_obj.path)
         response['X-Accel-Redirect'] = nginx_path
         self.default_headers(request=request, response=response, file_obj=file_obj, **kwargs)


### PR DESCRIPTION
Default django header Content-Type is 'text/html'. When nginx gets X-Accel-Redirect  response, if it contains a Content-Type nginx will not try to guess mimetype of file, and will return wrong Content-Type Header (text/html). 
So download will fail in most navigators (tested firefox and chrome)

Nginx docs says that nginx will only try to guess content-type  if response has no Content-Type header.

I got the issue, and this patch works for me. 

Other solution would be to ignore content-type in nginx. But "uwsgi_ignore_headers" directive does not allow Content-Type ignores. I think other backends as fastcgi would.

This patch delete content-type header for nginx server backend, to make nginx guess mimetype.

_note_: django-cms  crashed on multilingual midlleware if no Content-Type header in django-response. But pull-request has just been accepted to address this issue: divio#1392 
