### PR TITLE
Validate related

### DIFF
--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -115,20 +115,8 @@ class FilerFileField(models.ForeignKey):
     def __init__(self, **kwargs):
         # we call ForeignKey.__init__ with the Image model as parameter...
         # a FilerImageFiled can only be a ForeignKey to a Image
-        # self.validate_related_name(kwargs.get('related_name', None))
         return super(FilerFileField, self).__init__(
-                                        self.default_model_class, **kwargs)
-
-    def validate_related_name(self, name):
-        if not name:
-            return
-        if name and hasattr(self.default_model_class, name):
-            raise ImproperlyConfigured(
-                ("%s fields cannot have related name %r, this property " + \
-                 "already exists on %s") % (self.__class__.__name__,
-                                  name,
-                                  self.default_form_class.__name__)
-            )
+            self.default_model_class, **kwargs)
 
     def formfield(self, **kwargs):
         # This is a fairly standard way to set up some defaults

--- a/filer/tests/fields.py
+++ b/filer/tests/fields.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-from django.core.exceptions import ImproperlyConfigured
-from django.test.testcases import TestCase
-from filer.fields.image import FilerImageField
-
-class FieldsTests(TestCase):
-    def test_related_name_validation(self):
-        self.assertRaises(ImproperlyConfigured, FilerImageField, related_name='thumbnails')
-        FilerImageField(related_name='not_thumbnails')


### PR DESCRIPTION
Here is a pull request that removes the validate_related_name method from the field. As discussed in this issue: https://github.com/stefanfoulis/django-filer/issues/148
