### PR TITLE
Fix popup mode when Folder doesn't exists

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -208,6 +208,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
                 Folder.objects.get(id=last_folder_id)
             except Folder.DoesNotExist:
                 url = reverse('admin:filer-directory_listing-root')
+                url = "%s%s%s" % (url, popup_param(request), selectfolder_param(request,"&"))
             else:
                 url = reverse('admin:filer-directory_listing', kwargs={'folder_id': last_folder_id})
                 url = "%s%s%s" % (url, popup_param(request), selectfolder_param(request,"&"))


### PR DESCRIPTION
I noticed this bug in django_cms image plugin when trying to select an image for the first time.
If the last visited folder was the root folder or the unfiled folder, the popup mode doesn't trigger.

It's fixed with this simple patch ;)

cheers !
