### PR TITLE
Remove unused templatetag from django 1.4. Fixes #271

### DIFF
--- a/filer/templates/admin/filer/delete_confirmation.html
+++ b/filer/templates/admin/filer/delete_confirmation.html
@@ -1,7 +1,6 @@
 {% extends "admin/filer/base_site.html" %}
 {% load i18n %}
 {% load url from future %}
-{% load admin_urls %}
 
 {% block breadcrumbs %}
 {% include "admin/filer/breadcrumbs.html" with instance=object breadcrumbs_action="Delete" %}


### PR DESCRIPTION
An (unused) templatetag from django 1.4 slipped in.
Removed

Fixes #271
