### PR TITLE
respect THUMBNAIL_PRESERVE_EXTENSIONS

### DIFF
--- a/filer/utils/filer_easy_thumbnails.py
+++ b/filer/utils/filer_easy_thumbnails.py
@@ -30,7 +30,12 @@ class ThumbnailerNameMixin(object):
         filename.
         """
         path, source_filename = os.path.split(self.name)
-        if transparent:
+        source_extension = os.path.splitext(source_filename)[1][1:]
+        if self.thumbnail_preserve_extensions is True or  \
+            (self.thumbnail_preserve_extensions and
+             source_extension.lower() in self.thumbnail_preserve_extensions):
+                extension = source_extension
+        elif transparent:
             extension = self.thumbnail_transparency_extension
         else:
             extension = self.thumbnail_extension


### PR DESCRIPTION
Easy Thumbnails' THUMBNAIL_PRESERVE_EXTENSIONS option was being ignored.

This is basically the same implementation as it is in Easy Thumbnails and avoids odd behavior where setting this option doesn't seem to produce a desired behavior.

Ability to keep same format helps avoiding blemishes when resizing things like corporate logos.
