### PR TITLE
Remove unused method Clipboard.empty

### DIFF
--- a/filer/models/clipboardmodels.py
+++ b/filer/models/clipboardmodels.py
@@ -25,11 +25,6 @@ class Clipboard(models.Model):
             newitem.save()
             return True
 
-    def empty(self):
-        for item in self.bucket_items.all():
-            item.delete()
-    empty.alters_data = True
-
     def __unicode__(self):
         return u"Clipboard %s of %s" % (self.id, self.user)
 


### PR DESCRIPTION
This method seems to be a left-over from django-image-filer when the clipboard was named a bucket
Even if the method would be used, it would raise an AttributeError since it has no bucket_items attribute
