### PR TITLE
Fix error raising in FILER_DEBUG mode

### DIFF
--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -37,7 +37,7 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
                 if filer_settings.FILER_ENABLE_LOGGING:
                     logger.error('Error while rendering file widget: %s',e)
                 if filer_settings.FILER_DEBUG:
-                    raise e
+                    raise
         if not related_url:
             related_url = reverse('admin:filer-directory_listing-last')
         params = self.url_parameters()

--- a/filer/models/imagemodels.py
+++ b/filer/models/imagemodels.py
@@ -167,7 +167,7 @@ class Image(File):
                 if filer_settings.FILER_ENABLE_LOGGING:
                     logger.error('Error while generating icons: %s',e)
                 if filer_settings.FILER_DEBUG:
-                    raise e
+                    raise
         return _icons
 
     @property
@@ -185,7 +185,7 @@ class Image(File):
                 if filer_settings.FILER_ENABLE_LOGGING:
                     logger.error('Error while generating thumbnail: %s',e)
                 if filer_settings.FILER_DEBUG:
-                    raise e
+                    raise
         return _thumbnails
 
     @property


### PR DESCRIPTION
Re-raising the error modifies the traceback and makes it hard to debug.
Just calling raise in a except statement re-raises the error with
its full traceback, making it easier to debug.
