### PR TITLE
Don't call get_user_model in models modules

### DIFF
--- a/filer/models/clipboardmodels.py
+++ b/filer/models/clipboardmodels.py
@@ -1,16 +1,12 @@
 #-*- coding: utf-8 -*-
-try:
-    from django.contrib.auth import get_user_model
-    User = get_user_model()
-except ImportError:
-    from django.contrib.auth.models import User  # NOQA
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 from filer.models import filemodels
 
 
 class Clipboard(models.Model):
-    user = models.ForeignKey(User, verbose_name=_('user'), related_name="filer_clipboards")
+    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), verbose_name=_('user'), related_name="filer_clipboards")
     files = models.ManyToManyField(
                         'File', verbose_name=_('files'), related_name="in_clipboards",
                         through='ClipboardItem')

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -1,10 +1,6 @@
 #-*- coding: utf-8 -*-
-try:
-    from django.contrib.auth import get_user_model
-    User = get_user_model()
-except ImportError:
-    from django.contrib.auth.models import User  # NOQA
 from django.core import urlresolvers
+from django.conf import settings
 from django.core.files.base import ContentFile
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
@@ -49,7 +45,7 @@ class File(PolymorphicModel, mixins.IconsMixin):
     description = models.TextField(null=True, blank=True,
         verbose_name=_('description'))
 
-    owner = models.ForeignKey(User,
+    owner = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
         related_name='owned_%(class)ss',
         null=True, blank=True, verbose_name=_('owner'))
 

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -1,9 +1,4 @@
 #-*- coding: utf-8 -*-
-try:
-    from django.contrib.auth import get_user_model
-    User = get_user_model()
-except ImportError:
-    from django.contrib.auth.models import User  # NOQA
 from django.contrib.auth import models as auth_models
 from django.core import urlresolvers
 from django.core.exceptions import ValidationError
@@ -11,6 +6,7 @@ from django.db import models
 from django.db.models import Q
 from django.utils.http import urlquote
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 from filer.models import mixins
 from filer import settings as filer_settings
 
@@ -102,7 +98,7 @@ class Folder(models.Model, mixins.IconsMixin):
                                related_name='children')
     name = models.CharField(_('name'), max_length=255)
 
-    owner = models.ForeignKey(User, verbose_name=('owner'),
+    owner = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'), verbose_name=('owner'),
                               related_name='filer_owned_folders',
                               null=True, blank=True)
 
@@ -252,7 +248,7 @@ class FolderPermission(models.Model):
     folder = models.ForeignKey(Folder, verbose_name=('folder'), null=True, blank=True)
 
     type = models.SmallIntegerField(_('type'), choices=TYPES, default=ALL)
-    user = models.ForeignKey(User,
+    user = models.ForeignKey(getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
                              related_name="filer_folder_permissions",
                              verbose_name=_("user"), blank=True, null=True)
     group = models.ForeignKey(auth_models.Group,


### PR DESCRIPTION
You are not allowed to call get_user_model in a models module[1](https://docs.djangoproject.com/en/1.5/topics/auth/customizing/#django.contrib.auth.get_user_model). Doing so seems to work, but can cause circular imports in some situations, depending on your import structure and ordering of INSTALLED_APPS. This is because get_model loads the entire app cache, importing every model.
