### PR TITLE
Alternative fix for #321

### DIFF
--- a/filer/templates/admin/filer/delete_confirmation.html
+++ b/filer/templates/admin/filer/delete_confirmation.html
@@ -1,37 +1,11 @@
-{% extends "admin/filer/base_site.html" %}
-{% load i18n %}
+{% extends "admin/delete_confirmation.html" %}
+{% load i18n filermedia %}
 {% load url from future %}
 
-{% block breadcrumbs %}
-{% include "admin/filer/breadcrumbs.html" with instance=object breadcrumbs_action="Delete" %}
+{% block extrastyle %}{{ block.super }}
+    <link rel="stylesheet" type="text/css" href="{% filer_staticmedia_prefix %}css/admin_style.css" />
 {% endblock %}
 
-{% block content %}
-{% if perms_lacking or protected %}
-    {% if perms_lacking %}
-        <p>{% blocktrans with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would result in deleting related objects, but your account doesn't have permission to delete the following types of objects:{% endblocktrans %}</p>
-        <ul>
-        {% for obj in perms_lacking %}
-            <li>{{ obj }}</li>
-        {% endfor %}
-        </ul>
-    {% endif %}
-    {% if protected %}
-        <p>{% blocktrans with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would require deleting the following protected related objects:{% endblocktrans %}</p>
-        <ul>
-        {% for obj in protected %}
-            <li>{{ obj }}</li>
-        {% endfor %}
-        </ul>
-    {% endif %}
-{% else %}
-    <p>{% blocktrans with escaped_object=object %}Are you sure you want to delete the {{ object_name }} "{{ escaped_object }}"? All of the following related items will be deleted:{% endblocktrans %}</p>
-    <ul>{{ deleted_objects|unordered_list }}</ul>
-    <form action="" method="post">{% csrf_token %}
-    <div>
-    <input type="hidden" name="post" value="yes" />
-    <input type="submit" value="{% trans "Yes, I'm sure" %}" />
-    </div>
-    </form>
-{% endif %}
+{% block breadcrumbs %}
+    {% include "admin/filer/breadcrumbs.html" with instance=object breadcrumbs_action="Delete" %}
 {% endblock %}


### PR DESCRIPTION
Restore the inheritance for delete_confirmation template from django's one and adds filer specific css / code. Thanks to @acatton
