### PR TITLE
Excluded Django master and Python 2.6 build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ script: coverage run --rcfile=coverage.rc setup.py test
 after_success:
   coveralls --config_file=coverage.rc
 matrix:
-  allow_failures:
+  exclude:
     - python: 2.6
       env: DJANGO="https://github.com/django/django/archive/master.zip" EASY_THUMBNAILS="easy-thumbnails>=1.4"
+  allow_failures:
     - python: 2.7
       env: DJANGO="https://github.com/django/django/archive/master.zip" EASY_THUMBNAILS="easy-thumbnails>=1.4"

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,6 @@ deps =
     Pillow
     argparse
 
-
 [testenv:py27-django15]
 basepython = python2.7
 deps =
@@ -56,14 +55,6 @@ basepython = python2.7
 deps =
     Django>=1.6,<1.7
     Pillow
-
-[testenv:py26-django-dev]
-basepython = python2.6
-deps =
-    git+git://github.com/django/django.git#egg=Django
-    git+git://github.com/SmileyChris/easy-thumbnails.git#egg=easy-thumbnails
-    Pillow
-    argparse
 
 [testenv:py27-django-dev]
 basepython = python2.7


### PR DESCRIPTION
Django master (1.7) has dropped support for Python 2.6.
