### PR TITLE
Remove duplicate attributes from passed kwargs

### DIFF
--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -111,6 +111,8 @@ class FilerFileField(models.ForeignKey):
     def __init__(self, **kwargs):
         # we call ForeignKey.__init__ with the Image model as parameter...
         # a FilerImageFiled can only be a ForeignKey to a Image
+        if "to" in kwargs.keys():
+            kwargs.pop("to")
         return super(FilerFileField, self).__init__(
             self.default_model_class, **kwargs)
 

--- a/filer/fields/multistorage_file.py
+++ b/filer/fields/multistorage_file.py
@@ -97,6 +97,8 @@ class MultiStorageFileField(easy_thumbnails_fields.ThumbnailerField):
 
     def __init__(self, verbose_name=None, name=None,
                  storages=None, thumbnail_storages=None, thumbnail_options=None, **kwargs):
+        if 'upload_to' in kwargs:
+            kwargs.pop('upload_to')
         self.storages = storages or STORAGES
         self.thumbnail_storages = thumbnail_storages or THUMBNAIL_STORAGES
         self.thumbnail_options = thumbnail_options or THUMBNAIL_OPTIONS


### PR DESCRIPTION
Duplicate attributes were being passed to these models at import time through the kwargs. 
