### PR TITLE
Fixing leaks.

### DIFF
--- a/filer/models/imagemodels.py
+++ b/filer/models/imagemodels.py
@@ -194,7 +194,7 @@ class Image(File):
     @property
     def easy_thumbnails_thumbnailer(self):
         tn = FilerThumbnailer(
-            file=self.file.file, name=self.file.name,
+            file=self.file, name=self.file.name,
             source_storage=self.file.source_storage,
             thumbnail_storage=self.file.thumbnail_storage,
             thumbnail_basedir=self.file.thumbnail_basedir)


### PR DESCRIPTION
Passing the File object instead of the file descriptor to FilerThumbnails avoids unnecessary file opening.

Fix #310
