### PR TITLE
Safe translation of "file missing" in JavaScript

### DIFF
--- a/filer/templates/admin/filer/tools/upload_button_js.html
+++ b/filer/templates/admin/filer/tools/upload_button_js.html
@@ -1,6 +1,5 @@
 {% load i18n admin_modify filermedia %}
 {% load url from future %}
-{% trans "file missing" as file_missing %}
 
 <script type="text/javascript">
 //<![CDATA[
@@ -22,7 +21,7 @@ $(function() {
             var file = responseJSON;
             if (file.error) {
                 var html = '\
-                <td class="thumbnail"><img style="width: 32px;height: 32px;" src="{% filer_staticmedia_prefix %}/icons/missingfile_32x32.png" alt="{{ file_missing|escapejs }}" /></td>\
+                <td class="thumbnail"><img style="width: 32px;height: 32px;" src="{% filer_staticmedia_prefix %}/icons/missingfile_32x32.png" alt="{% filter escapejs %}{% trans "file missing" %}{% endfilter %}" /></td>\
                 <td class="label">' + file.error + '</td>\
                 <td class="buttons"></td>';
             } else {


### PR DESCRIPTION
File uploader button is not working when using django in Catalan, because the translation of "file missing" is breaking the Javascript code.

I propose to use this translation escaped. It should not be modified at the translation, as this text appears in another file, in normal html.
