### PR TITLE
Add the owner_search_fields option to FolderAdmin.

### DIFF
--- a/docs/extending_filer.rst
+++ b/docs/extending_filer.rst
@@ -178,3 +178,30 @@ You might want to extend this, so that the list includes the apprpriate informat
         file_type = 'Video'
         
 Note that if you do this, you *will* need to override the template - otherwise your items will fail to display in the folder lists.
+
+Overriding the Directory Listing Search
+---------------------------------------
+
+By default, filer will search against ``name`` for :py:class:`Folders
+<filer.models.foldermodels.Folder>` and ``name``, ``description``, and
+``original_filename`` for :py:class:`Files <filer.models.filemodels.File>`, in
+addition to searching against the owner.  If you are using ``auth.User`` as
+your User model, filer will search against the ``username``, ``first_name``,
+``last_name``, ``email`` fields.  If you are using a custom User model, filer
+will search against all fields that are CharFields except for the password
+field.  You can override this behavior by subclassing the
+:py:class:`filer.admin.folderadmin.FolderAdmin` class and overriding the
+:py:attr:`~filer.admin.FolderAdmin.owner_search_fields` property.
+
+.. code-block:: python
+
+    # in an admin.py file
+    from django.contrib import admin
+    from filer.admin import FolderAdmin
+    from filer.models import Folder
+
+    class MyFolderAdmin(FolderAdmin):
+        owner_search_fields = ['field1', 'field2']
+
+    admin.site.unregister(Folder)
+    admin.site.register(Folder, FolderAdmin)

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -12,7 +12,7 @@ from filer.admin.patched.admin_utils import get_deleted_objects
 from django.core.exceptions import PermissionDenied
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
-from django.db import router
+from django.db import router, models
 from django.db.models import Q
 from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import render_to_response, get_object_or_404
@@ -399,25 +399,47 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
                         permissions.get("has_add_children_permission"),
         }, context_instance=RequestContext(request))
 
-    @staticmethod
-    def filter_folder(qs, terms=[]):
+    def filter_folder(self, qs, terms=[]):
         for term in terms:
-            qs = qs.filter(Q(name__icontains=term) |
-                           Q(owner__username__icontains=term) |
-                           Q(owner__first_name__icontains=term) |
-                           Q(owner__last_name__icontains=term))
+            filters = Q(name__icontains=term)
+            for filter_ in self.get_owner_filter_lookups():
+                filters |= Q(**{filter_: term})
+            qs = qs.filter(filters)
         return qs
 
-    @staticmethod
-    def filter_file(qs, terms=[]):
+    def filter_file(self, qs, terms=[]):
         for term in terms:
-            qs = qs.filter(Q(name__icontains=term) |
-                           Q(description__icontains=term) |
-                           Q(original_filename__icontains=term) |
-                           Q(owner__username__icontains=term) |
-                           Q(owner__first_name__icontains=term) |
-                           Q(owner__last_name__icontains=term))
+            filters = (Q(name__icontains=term) |
+                       Q(description__icontains=term) |
+                       Q(original_filename__icontains=term))
+            for filter_ in self.get_owner_filter_lookups():
+                filters |= Q(**{filter_: term})
+            qs = qs.filter(filters)
         return qs
+
+    @property
+    def owner_search_fields(self):
+        """
+        Returns all the fields that are CharFields except for password from the
+        User model.  For the built-in User model, that means username,
+        first_name, last_name, and email.
+        """
+        try:
+            from django.contrib.auth import get_user_model
+        except ImportError:  # Django < 1.5
+            from django.contrib.auth.models import User
+        else:
+            User = get_user_model()
+        return [
+            field.name for field in User._meta.fields
+            if isinstance(field, models.CharField) and field.name != 'password'
+        ]
+
+    def get_owner_filter_lookups(self):
+        return [
+            'owner__{field}__icontains'.format(field=field)
+            for field in self.owner_search_fields
+        ]
 
     def response_action(self, request, files_queryset, folders_queryset):
         """


### PR DESCRIPTION
In order to make it easier to work with custom User models, I have added
an owner_search_fields option to the FolderAdmin class, which
1.  Allows users to declare which search fields they want.
2.  Attempts to discover which fields are available on the User model
     and using those.

This makes it a lot easier to avoid errors when there are custom User
models.
