### PR TITLE
Fix mismatched double quotes in filer admin templates

### DIFF
--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -14,7 +14,7 @@
 <a href="{{ lookup_url }}" class="related-lookup" id="lookup_id_{{ lookup_name }}" title="{% trans 'Lookup' %}" onclick="return showRelatedObjectLookupPopup(this);">
 	<img src="{% admin_icon_base %}icon_searchbox.png" width="16" height="16" alt="{% trans 'Lookup' %}" />
 </a>
-<img id="{{ clear_id }}" src="{% admin_icon_base %}icon_deletelink.gif" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %}" />
+<img id="{{ clear_id }}" src="{% admin_icon_base %}icon_deletelink.gif" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %} />
 <br />
 {{ hidden_input }}
 <script type="text/javascript">

--- a/filer/templates/admin/filer/widgets/admin_folder.html
+++ b/filer/templates/admin/filer/widgets/admin_folder.html
@@ -7,7 +7,7 @@
 <a href="{{ lookup_url }}" class="related-lookup" id="lookup_id_{{ lookup_name }}" title="{% trans 'Lookup' %}" onclick="return showRelatedObjectLookupPopup(this);">
 	<img src="{% admin_icon_base %}icon_searchbox.png" width="16" height="16" alt="{% trans 'Lookup' %}" />
 </a>
-<img id="{{ clear_id }}" src="{% admin_icon_base %}icon_deletelink.gif" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %}" />
+<img id="{{ clear_id }}" src="{% admin_icon_base %}icon_deletelink.gif" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %} />
 <br />
 {{ hidden_input }}
 <script type="text/javascript">django.jQuery("#{{ id }}").hide();


### PR DESCRIPTION
Fixes the problem described in this issue: https://github.com/stefanfoulis/django-filer/issues/353
