### PR TITLE
fix for django v1.7: delete & access incorrect key

### DIFF
--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -112,9 +112,9 @@ class FilerFileField(models.ForeignKey):
         # we call ForeignKey.__init__ with the Image model as parameter...
         # a FilerImageField can only be a ForeignKey to a Image
         if "to" in kwargs.keys():
-            kwargs.pop("to")
+            old_to = kwargs.pop("to")
             warnings.warn("FilerImageField can only be a ForeignKey to a Image;"
-                          "%s passed" % kwargs['to'], SyntaxWarning)
+                          "%s passed" % old_to, SyntaxWarning)
         return super(FilerFileField, self).__init__(self.default_model_class,
                                                     **kwargs)
 

--- a/filer/fields/multistorage_file.py
+++ b/filer/fields/multistorage_file.py
@@ -101,9 +101,9 @@ class MultiStorageFileField(easy_thumbnails_fields.ThumbnailerField):
     def __init__(self, verbose_name=None, name=None,
                  storages=None, thumbnail_storages=None, thumbnail_options=None, **kwargs):
         if 'upload_to' in kwargs:
-            kwargs.pop("to")
+            upload_to = kwargs.pop("upload_to")
             warnings.warn("MultiStorageFileField can handle only File objects;"
-                          "%s passed" % kwargs['to'], SyntaxWarning)
+                          "%s passed" % upload_to, SyntaxWarning)
         self.storages = storages or STORAGES
         self.thumbnail_storages = thumbnail_storages or THUMBNAIL_STORAGES
         self.thumbnail_options = thumbnail_options or THUMBNAIL_OPTIONS


### PR DESCRIPTION
I fix the bug mentioned here: https://github.com/stefanfoulis/django-filer/issues/429. It is anticipated that this bug is repeatable in Django 1.6.

Hopefully someone can update the unit test so as to run in Django 1.7. I tried but it is too time consuming to solve South migration problem in all the depended libraries.
