### PR TITLE
fix #340

### DIFF
--- a/filer/utils/files.py
+++ b/filer/utils/files.py
@@ -6,7 +6,7 @@ from django.utils.text import get_valid_filename as get_valid_filename_django
 from django.template.defaultfilters import slugify as slugify_django
 from django.http.multipartparser import ChunkIter, exhaust, \
     StopFutureHandlers, SkipFile, StopUpload
-from unihandecode import unidecode
+from unidecode import unidecode
 
 class UploadException(Exception):
     pass

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         'easy-thumbnails>=1.0',
         'django-mptt==0.5.2,==0.6,==0.6.1',
         'django_polymorphic>=0.2',
-        'Unihandecode>=0.40,<=0.43',
+        'Unidecode>=0.04',
     ),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
this patchset is intended to fix #340. `unihandecode` version is set to 0.43 until miurahr/unihandecode#23 is fixed.
