### PR TITLE
Fix FolderPermission.__str__ method

### DIFF
--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -291,7 +291,7 @@ class FolderPermission(models.Model):
                 perms.append('!%s' % s)
         perms = ', '.join(perms)
         return "Folder: '%s'->%s [%s] [%s]" % (
-                        name, str(self.TYPES[self.type][1]),
+                        name, self.get_type_display(),
                         perms, usergroup)
 
     def clean(self):


### PR DESCRIPTION
Use `self.get_type_display()` instead of manually getting correct item from `self.TYPES`. This will display correctly the type label instead of something like `<django.utils.functional.__proxy__ object at 0xa9b5b4c>`
