### PR TITLE
fix Django migrations to support custom Image model (FILER_IMAGE_MODEL)

### DIFF
--- a/filer/migrations_django/0001_initial.py
+++ b/filer/migrations_django/0001_initial.py
@@ -102,26 +102,6 @@ class Migration(migrations.Migration):
             },
             bases=(models.Model,),
         ),
-        migrations.CreateModel(
-            name='Image',
-            fields=[
-                ('file_ptr', models.OneToOneField(serialize=False, auto_created=True, to='filer.File', primary_key=True, parent_link=True)),
-                ('_height', models.IntegerField(null=True, blank=True)),
-                ('_width', models.IntegerField(null=True, blank=True)),
-                ('date_taken', models.DateTimeField(verbose_name='date taken', null=True, editable=False, blank=True)),
-                ('default_alt_text', models.CharField(max_length=255, null=True, verbose_name='default alt text', blank=True)),
-                ('default_caption', models.CharField(max_length=255, null=True, verbose_name='default caption', blank=True)),
-                ('author', models.CharField(max_length=255, null=True, verbose_name='author', blank=True)),
-                ('must_always_publish_author_credit', models.BooleanField(default=False, verbose_name='must always publish author credit')),
-                ('must_always_publish_copyright', models.BooleanField(default=False, verbose_name='must always publish copyright')),
-                ('subject_location', models.CharField(default=None, max_length=64, null=True, verbose_name='subject location', blank=True)),
-            ],
-            options={
-                'verbose_name': 'image',
-                'verbose_name_plural': 'images',
-            },
-            bases=('filer.file',),
-        ),
         migrations.AlterUniqueTogether(
             name='folder',
             unique_together=set([('parent', 'name')]),

--- a/filer/migrations_django/0002_image.py
+++ b/filer/migrations_django/0002_image.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from filer.settings import FILER_IMAGE_MODEL
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('filer', '0001_initial'),
+        migrations.swappable_dependency(FILER_IMAGE_MODEL or 'filer.models.imagemodels.Image'),
+    ]
+
+    operations = []
+    if not FILER_IMAGE_MODEL:
+        operations.append(
+            migrations.CreateModel(
+                name='Image',
+                fields=[
+                    ('file_ptr', models.OneToOneField(serialize=False, auto_created=True, to='filer.File', primary_key=True, parent_link=True)),
+                    ('_height', models.IntegerField(null=True, blank=True)),
+                    ('_width', models.IntegerField(null=True, blank=True)),
+                    ('date_taken', models.DateTimeField(verbose_name='date taken', null=True, editable=False, blank=True)),
+                    ('default_alt_text', models.CharField(max_length=255, null=True, verbose_name='default alt text', blank=True)),
+                    ('default_caption', models.CharField(max_length=255, null=True, verbose_name='default caption', blank=True)),
+                    ('author', models.CharField(max_length=255, null=True, verbose_name='author', blank=True)),
+                    ('must_always_publish_author_credit', models.BooleanField(default=False, verbose_name='must always publish author credit')),
+                    ('must_always_publish_copyright', models.BooleanField(default=False, verbose_name='must always publish copyright')),
+                    ('subject_location', models.CharField(default=None, max_length=64, null=True, verbose_name='subject location', blank=True)),
+                ],
+                options={
+                    'verbose_name': 'image',
+                    'verbose_name_plural': 'images',
+                },
+                bases=('filer.file',),
+            )
+        )


### PR DESCRIPTION
Trying to syncdb with Django 1.7 when using custom image model (FILER_IMAGE_MODEL setting) fails.
First I tried adding swappable_dependency to initial migration but this also fails because app with custom Image model has to depend on Filer's 0001_initial migration (for File table) and this results in circular dependency error.
So I created 0002 migration specifically for Image model. It also skips filer_image table creation if custom Image model is used (I think this is logical because default Image model is effectively unavailable when custom model is used).
It's also worth noting that the app with custom model must have custom image model's table created in the initial migration (not in subsequent migrations). So I suppose it would be good to copy the following 2 warnings from Django docs to Filer's docs:
https://docs.djangoproject.com/en/1.7/topics/auth/customizing/#substituting-a-custom-user-model
