### PR TITLE
Don't use multiple '==' version specifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         # 'Django>=1.4,<1.5',  # no need to limit while in development
         'Django>=1.4',
         'easy-thumbnails>=1.0',
-        'django-mptt==0.5.2,==0.6,==0.6.1',
+        'django-mptt>=0.6',
         'django_polymorphic>=0.2',
         'Unidecode>=0.04',
     ),


### PR DESCRIPTION
PEP-440 specifies that 'The comma (",") is equivalent to a logical and operator: a candidate version must match all given version clauses in order to match the specifier as a whole.'

Fixes #477

See also https://github.com/pypa/pip/issues/2258
