### PR TITLE
import_files refactoring

### DIFF
--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -41,7 +41,7 @@ class FileImporter(object):
         self.storage = storage_class(**stor_kwargs)
         self.dup_action = dup_action
         self.verbosity = int(verbosity)
-        self.files_created = {} # mapping of <file class>:<how many have been created>
+        self.files_created = {}  # mapping of <file class>:<how many have been created>
         self.folder_created = 0
         self.target_folder = None
         folder_name = 'root folder'
@@ -65,20 +65,20 @@ class FileImporter(object):
         # find the file type
         for filer_class in filer_settings.FILER_FILE_MODELS:
             FileSubClass = load_object(filer_class)
-            #TODO: What if there are more than one that qualify?
+            # TODO: What if there are more than one that qualify?
             if FileSubClass.matches_file_type(basename, None, None):
                 obj = FileSubClass(
-                        original_filename=basename,
-                        file=file_obj,
-                        folder=folder,
-                        is_public=filer_settings.FILER_IS_PUBLIC_DEFAULT)
+                    original_filename=basename,
+                    file=file_obj,
+                    folder=folder,
+                    is_public=filer_settings.FILER_IS_PUBLIC_DEFAULT)
                 class_name = FileSubClass.__name__
                 if class_name not in self.files_created:
                     self.files_created[class_name] = 0
                 break
         # check if such file was already imported in this folder
         duplicates = folder.all_files.filter(
-                        original_filename__exact=basename)
+            original_filename__exact=basename)
         if self.dup_action != DUPLICATE_ACTIONS.new and duplicates.count():
             dup_action = self.dup_action
             if dup_action is None:
@@ -95,10 +95,10 @@ class FileImporter(object):
                 del_orphan_file(obj)
                 obj.file = file_obj
             elif dup_action == DUPLICATE_ACTIONS.update:
-                obj.generate_sha1() # generate sha1 now to compare
+                obj.generate_sha1()  # generate sha1 now to compare
                 diff_sha_q = duplicates.exclude(sha1__exact=obj.sha1)
                 if not diff_sha_q.count():
-                    return None # no need to update, skip
+                    return None  # no need to update, skip
                 obj = diff_sha_q.first()
                 del_orphan_file(obj)
                 obj.file = file_obj
@@ -194,7 +194,7 @@ class Command(BaseCommand):
             default=None,
             help='Specify constanct action when duplicate file is found in Filer '
                  '(one of %s)' % list(DUPLICATE_ACTIONS)),
-        )
+    )
 
     def handle(self, *paths, **options):
         if not len(paths):
@@ -213,4 +213,3 @@ class Command(BaseCommand):
         file_importer = FileImporter(**options)
         for path in paths:
             file_importer.import_path(path)
-

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -5,8 +5,8 @@ import os
 from collections import namedtuple
 from optparse import make_option
 
-from django.core.files.storage import get_storage_class
-from django.core.management.base import BaseCommand, NoArgsCommand
+from django.core.files.storage import FileSystemStorage, get_storage_class
+from django.core.management.base import BaseCommand, CommandError
 
 from ... import settings as filer_settings
 from ...models.filemodels import File
@@ -19,19 +19,35 @@ DuplicateActions = namedtuple('DuplicateActions', _dup_actions)
 DUPLICATE_ACTIONS = DuplicateActions(*_dup_actions)
 
 
+def normpath(path, no_dots=True, expand_user=False):
+    if not path:
+        return ''
+    ret_path = path
+    if expand_user:
+        ret_path = os.path.expanduser(upath(ret_path))
+    ret_path = os.path.normpath(ret_path)
+    if no_dots and ret_path.startswith('.'):
+        raise CommandError("Path '%s'->'%s' cannot be '.' or be relatively up (start with '..')" % (path, ret_path))
+    return ret_path
+
+
 class FileImporter(object):
-    def __init__(self, * args, **kwargs):
-        self.path = kwargs.get('path') or ''
-        self.base_folder = kwargs.get('base_folder') or ''
-        # prevent trailing slashes and other inconsistencies on path.
-        self.path = os.path.expanduser(upath(self.path))
-        self.path = os.path.normpath(self.path)
-        self.base_folder = os.path.normpath(upath(self.base_folder))
-        self.storage = kwargs.get('storage_class')(location=self.path)
-        self.dup_action = kwargs.get('dup_action')
-        self.verbosity = int(kwargs.get('verbosity', 1))
-        self.files_created = {}  # mapping of <file class>:<how many have been created>
+    def __init__(self, path, base_folder, storage_class, dup_action, verbosity=1, **kwargs):
+        base_folder = normpath(base_folder)
+        stor_kwargs = {}
+        if path:
+            stor_kwargs['location'] = path
+        self.storage = storage_class(**stor_kwargs)
+        self.dup_action = dup_action
+        self.verbosity = int(verbosity)
+        self.files_created = {} # mapping of <file class>:<how many have been created>
         self.folder_created = 0
+        self.target_folder = None
+        folder_name = 'root folder'
+        if base_folder:
+            self.target_folder = self.get_or_create_folder(base_folder.split('/'))
+            folder_name = "folder '%s'" % base_folder
+        print("Selected paths will be imported into filer's %s" % folder_name)
 
     def import_file(self, file_obj, folder, file_path):
         """
@@ -49,11 +65,11 @@ class FileImporter(object):
             FileSubClass = load_object(filer_class)
             # TODO: What if there are more than one that qualify?
             if FileSubClass.matches_file_type(file_obj.name, None, None):
-                obj = FileSubClass.objects.create(
-                    original_filename=file_obj.name,
-                    file=file_obj,
-                    folder=folder,
-                    is_public=filer_settings.FILER_IS_PUBLIC_DEFAULT)
+                obj = FileSubClass(
+                        original_filename=os.path.basename(file_obj.name),
+                        file=file_obj,
+                        folder=folder,
+                        is_public=filer_settings.FILER_IS_PUBLIC_DEFAULT)
                 class_name = FileSubClass.__name__
                 if class_name not in self.files_created:
                     self.files_created[class_name] = 0
@@ -120,51 +136,49 @@ class FileImporter(object):
                     self._print_created('%s -- created : %s' % (parent, created))
         return parent
 
-    def _import_dir(self, path, target_folder):
+    def import_path(self, path):
+        path = normpath(path)
+        if self.verbosity >= 1:
+            print("Import the folders and files in %s" % (path,))
+        target_folder = self.get_or_create_folder(path.split('/'), self.target_folder)
+        self._import_dir(path, target_folder)
+
+    def _import_dir(self, path, folder):
         dirs, files = self.storage.listdir(path)
         for dir in dirs:
-            folder = self.get_or_create_folder((dir,), target_folder)
-            self._import_dir(os.path.join(path, dir), folder)
+            child_folder = self.get_or_create_folder((dir,), folder)
+            self._import_dir(os.path.join(path, dir), child_folder)
         for file in files:
             file_path = os.path.join(path, file)
             with self.storage.open(file_path) as dj_file:
-                self.import_file(dj_file, target_folder, file_path)
-
-    def walker(self):
-        """
-        This method walks a directory structure and creates
-        Folders and Files as they appear.
-        """
-        print("The directory structure will be imported in %s" % (self.base_folder,))
-        if self.verbosity >= 1:
-            print("Import the folders and files in %s" % (self.path,))
-        target_folder = self.get_or_create_folder(self.base_folder.split('/'))
-        self._import_dir('', target_folder)
+                self.import_file(dj_file, folder, file_path)
         if self.verbosity >= 1:
             self._print_created()
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     """
     Import directory structure into the filer ::
 
-        manage.py import_files --path=/tmp/assets/images
-        manage.py import_files --path=/tmp/assets/news --folder=images
-        manage.py import_files --path=/tmp --folder=a --storage=storages.backends.ftp.FTPStorage
-        manage.py import_files --path=/tmp/assets/news --folder=images --duplicate-action=update
+        manage.py import_files --path=/tmp/assets/images folder
+        manage.py import_files --path=/tmp/assets/news --folder=images other_folder
+        manage.py import_files --folder=a --storage=storages.backends.ftp.FTPStorage public_html
+        manage.py import_files --path=/tmp/assets/news --duplicate-action=update images content something
     """
 
+    help = __doc__
+    args = "<path_to_import path_to_import ...>"
     option_list = BaseCommand.option_list + (
         make_option('--path',
             action='store',
             dest='path',
-            default=None,
-            help='Import files located in the path into django-filer'),
+            default='',
+            help='Import paths starting at this base path. This is a current directory by default'),
         make_option('--folder',
             action='store',
             dest='base_folder',
-            default=None,
-            help='Specify the destination folder in which the directory structure should be imported'),
+            default='',
+            help='Specify the destination folder in which paths should be imported'),
         make_option('--storage',
             action='store',
             dest='storage_class',
@@ -176,12 +190,24 @@ class Command(NoArgsCommand):
             choices=DUPLICATE_ACTIONS,
             dest='dup_action',
             default=None,
-            help='Specify constanct action when duplicate file is already found in Filer '
+            help='Specify constanct action when duplicate file is found in Filer '
                  '(one of %s)' % list(DUPLICATE_ACTIONS)),
         )
 
-    def handle_noargs(self, **options):
+    def handle(self, *paths, **options):
+        if not len(paths):
+            raise CommandError('No paths to import provided!')
         options['storage_class'] = get_storage_class(options['storage_class'])
+        stor_is_filesystem = issubclass(options['storage_class'], FileSystemStorage)
+        if options['path']:
+            options['path'] = normpath(options['path'],
+                                       no_dots=not stor_is_filesystem,
+                                       expand_user=not stor_is_filesystem)
+        elif stor_is_filesystem:
+            # FileSystemStorage defaults to MEDIA_ROOT setting for location
+            # this is not a good default in this case, use current directory instead
+            options['path'] = os.getcwd()
         file_importer = FileImporter(**options)
-        file_importer.walker()
+        for path in paths:
+            file_importer.import_path(path)
 


### PR DESCRIPTION
This includes a rewrite of import_files which now has these features:
- Import from any Django storage
- Use standard File class detection (matches_file_type)
- Make import_files repeatable by adding duplicate file detection and user action selection. Now it is possible to import the same path to the same filer target folder by selecting --duplicate-action=update and only changed files will be overwriten, no duplicates will be created.

The big thing is size/image size/sha calculation optimization which turned out to be somewhat complicated. Now these file attributes are only recalculated from storage when file's url changes (the only proper way to detect if file contents were changed that I found). This could be improved though:
- File.sha1 could be renamed to _sha1, then get_sha() could be renamed to sha1 and become a property (just like size and image_size)
- get_file_id() could be improved and if we had a model field for this, database hit in data_changed() could be removed and FileQuerySet.iterator override wouldn't be necessary
