### PR TITLE
Easier File and Image model fields usage

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -6,7 +6,7 @@ Settings
 ``FILER_ENABLE_PERMISSIONS``
 ----------------------------
 
-Activate the or not the Permission check on the files and folders before 
+Activate the or not the Permission check on the files and folders before
 displaying them in the admin. When set to ``False`` it gives all the authorization
 to staff members based on standard Django model permissions.
 
@@ -73,7 +73,7 @@ Public storage uses ``DEFAULT_FILE_STORAGE`` as default storage backend.
 
 ``UPLOAD_TO`` is the function to generate the path relative to the storage root. The
 default generates a random path like ``1d/a5/1da50fee-5003-46a1-a191-b547125053a8/filename.jpg``. This
-will be applied whenever a file is uploaded or moved between public (without permission checks) and 
+will be applied whenever a file is uploaded or moved between public (without permission checks) and
 private (with permission checks) storages. Defaults to ``'filer.utils.generate_filename.randomized'``.
 
 
@@ -111,7 +111,7 @@ Defaults to ``20``
 ``FILER_SUBJECT_LOCATION_IMAGE_DEBUG``
 --------------------------------------
 
-Draws a red circle around to point in the image that was used to do the 
+Draws a red circle around to point in the image that was used to do the
 subject location aware image cropping.
 
 Defaults to ``False``
@@ -150,3 +150,30 @@ Number of simultaneous AJAX uploads. Defaults to 3.
 If your database backend is SQLite it would be set to 1 by default. This allows
 to avoid ``database is locked`` errors on SQLite during multiple simultaneous
 file uploads.
+
+
+``FILER_DEFAULT_FOLDER_GETTER``
+-------------------------------
+
+Path to a subclass of `filer.utils.folders.DefaultFolderGetter`.
+Methods name of this subclass can be used as value for the
+`default_folder_key` of ``FilerFileField`` and ``FilerImageField``.
+
+e.g::
+
+    FILER_DEFAULT_FOLDER_GETTER = 'myapp.handlers.FolderGetter'
+
+and in myapp/hanlers.py::
+
+    from filer.utils.folders import DefaultFolderGetter
+
+    class FolderGetter(DefaultFolderGetter):
+        @classmethod
+        def USER_OWN_FOLDER(cls, request):
+            if not request.user.is_authenticated():
+                return None
+            parent_kwargs = {
+                name: 'users_files',
+
+            }
+            return cls._get_or_create(name=user.username, owner=user, parent_kwargs=parent_kwargs)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -24,6 +24,28 @@ checksums.
      company.logo.icons['64'] # or {{ company.logo.icons.64 }} in a template
      company.logo.url         # prints path to original image
 
+``FileMimetypeValidator`` and preconfigured validators
+------------------------------------------------------
+
+``django-filer`` provides a validator to allow only files of some mimetypes.
+``FileMimetypeValidator`` require a mimetypes list and allow wildcard for 
+subtypes. eg : `image/jpeg` allow only JPEG files, but if you want to allow all
+image types, `image/*` is accepted.
+
+Some preconfigured validators are set:
+
+* `validate_audios` : allow all `audio/*` files
+* `validate_images` : allow all `images/*` files
+* `validate_videos` : allow all `video/*` files
+* `validate_html5_audios` : allow most supported audio file format for web integration
+  (wav, mp3, mp4, ogg, webm, aac)
+* `validate_html5_images` : allow most supported image file format for web integration
+  (jpeg, png, gif, svg)
+* `validate_html5_videos` : allow most supported video file format for web integration
+  (mp4, ogv, webm)
+* `validate_documents` : allow main document types 
+  (odt, ods, odpn, doc, xls, ppt, pdf, csv)
+
 
 ``FilerFileField`` and ``FilerImageField``
 ------------------------------------------
@@ -32,6 +54,17 @@ They are subclasses of `django.db.models.ForeignKey`_, so the same rules apply.
 The only difference is, that there is no need to declare what model we are
 referencing (it is always ``filer.models.File`` for the ``FilerFileField`` and
 ``filer.models.Image`` for the ``FilerImageField``).
+
+Those Fields have some specific and optionnal options :
+
+* `default_folder_key` : specify the folder handler key which will return the
+folder where files will be stored for direct upload, or the folder to open 
+when we use file lookup.
+* `default_direct_upload_enabled` : Allow use to upload a file inside the
+  main form (without opening the files lookup popup). Default is False
+  to stay backward compatible.
+* `default_file_lookup_enabled` : Allow user to choose (or add) files via
+  the file lookup popup (default is True)
 
 Simple example ``models.py``::
 
@@ -59,6 +92,30 @@ multiple file fields on the same model::
 As with `django.db.models.ForeignKey`_ in general, you have to define a
 non-clashing ``related_name`` if there are multiple ``ForeignKey`` s to the
 same model.
+
+
+Advanced exemple ``models.py``::
+
+    from django.db import models
+    from filer.fields.image import FilerImageField
+    from filer.fields.file import FilerFileField
+    from filer.validators import FileMimetypeValidator, validate_documents
+
+    class Company(models.Model):
+        name = models.CharField(max_length=255)
+        logo = FilerImageField(null=True, blank=True,
+                               help_text='JPEG only',
+                               default_direct_upload_enabled=True,
+                               default_file_lookup_enabled=False,
+                               default_folder_key='USERS_OWN_FOLDER',
+                               validators=[FileMimetypeValidator(['image/jpeg',]),],
+                               related_name="company_logo")
+        disclaimer = FilerFileField(null=True, blank=True,
+                                    default_direct_upload_enabled=True,
+                                    default_file_lookup_enabled=True,
+                                    default_folder_key='DOCUMENTS',
+                                    validators=[validate_documents,]
+                                    related_name="company_disclaimer")
 
 templates
 .........

--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -3,13 +3,12 @@
 import json
 from django.forms.models import modelform_factory
 from django.contrib import admin
-from django.db.models import get_model
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 
 from filer import settings as filer_settings
 from filer.models import Folder, Clipboard, ClipboardItem, Image
-from filer.utils.compatibility import DJANGO_1_4
+from filer.utils.compatibility import DJANGO_1_4, get_model
 from filer.utils.files import (
     handle_upload, handle_request_files_upload, UploadException,
 )

--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -3,6 +3,7 @@
 import json
 from django.forms.models import modelform_factory
 from django.contrib import admin
+from django.db.models import get_model
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 
@@ -13,6 +14,7 @@ from filer.utils.files import (
     handle_upload, handle_request_files_upload, UploadException,
 )
 from filer.utils.loader import load_object
+from filer.validators import FileMimetypeValidator
 
 
 NO_FOLDER_ERROR = "Can't find folder to upload. Please refresh and try again"
@@ -53,7 +55,16 @@ class ClipboardAdmin(admin.ModelAdmin):
             url(r'^operations/upload/(?P<folder_id>[0-9]+)/$',
                 ajax_upload,
                 name='filer-ajax_upload'),
-            url(r'^operations/upload/no_folder/$',
+            url((r'^operations/upload/'
+                 r'(?P<folder_key>\w*)/'
+                 r'(?P<related_field>\w+.\w+.\w+)/'
+                 r'$'),
+                ajax_upload,
+                name='filer-ajax_upload'),
+            url((r'^operations/upload/(?P<folder_key>\w*)/$'),
+                ajax_upload,
+                name='filer-ajax_upload'),
+            url((r'^operations/upload/no_folder/$'),
                 ajax_upload,
                 name='filer-ajax_upload'),
         )
@@ -72,34 +83,48 @@ class ClipboardAdmin(admin.ModelAdmin):
 
 
 @csrf_exempt
-def ajax_upload(request, folder_id=None):
+def ajax_upload(request, folder_id=None, folder_key=None, related_field=None):
     """
     Receives an upload from the uploader. Receives only one file at a time.
     """
     mimetype = "application/json" if request.is_ajax() else "text/html"
     content_type_key = 'mimetype' if DJANGO_1_4 else 'content_type'
     response_params = {content_type_key: mimetype}
-    folder = None
-    if folder_id:
-        try:
-            # Get folder
-            folder = Folder.objects.get(pk=folder_id)
-        except Folder.DoesNotExist:
-            return HttpResponse(json.dumps({'error': NO_FOLDER_ERROR}),
-                                **response_params)
-
-    # check permissions
-    if folder and not folder.has_add_children_permission(request):
-        return HttpResponse(
-            json.dumps({'error': NO_PERMISSIONS_FOR_FOLDER}),
-            **response_params)
+    mimetypes = []
     try:
+        if related_field:
+            related_field = related_field.split('.')
+            if len(related_field) != 3:
+                raise UploadException("Related field is not valid.")
+            try:
+                model = get_model(related_field[0], related_field[1])
+                field = model._meta.get_field_by_name(related_field[2])[0]
+            except:
+                raise UploadException("Related field is not valid.")
+            for validator in field.validators:
+                if isinstance(validator, FileMimetypeValidator):
+                    mimetypes += validator.mimetypes
+        folder = None
+        if folder_id:
+            try:
+                # Get folder
+                folder = Folder.objects.get(pk=folder_id)
+            except Folder.DoesNotExist:
+                return HttpResponse(json.dumps({'error': NO_FOLDER_ERROR}),
+                                    **response_params)
+        elif folder_key and folder_key != 'no_folder':
+            from filer.utils.folders import get_default_folder_getter
+            folder = get_default_folder_getter().get(folder_key, request)
+
+        # check permissions
+        if folder and not folder.has_add_children_permission(request):
+            raise UploadException(NO_PERMISSIONS_FOR_FOLDER)
         if len(request.FILES) == 1:
             # dont check if request is ajax or not, just grab the file
-            upload, filename, is_raw = handle_request_files_upload(request)
+            upload, filename, is_raw = handle_request_files_upload(request, mimetypes)
         else:
             # else process the request as usual
-            upload, filename, is_raw = handle_upload(request)
+            upload, filename, is_raw = handle_upload(request, mimetypes)
         # TODO: Deprecated/refactor
         # Get clipboad
         # clipboard = Clipboard.objects.get_or_create(user=request.user)[0]
@@ -175,8 +200,8 @@ def ajax_upload(request, folder_id=None):
                                 **response_params)
         else:
             form_errors = '; '.join(['%s: %s' % (
-                field,
-                ', '.join(errors)) for field, errors in list(
+                fieldname,
+                ', '.join(errors)) for fieldname, errors in list(
                     uploadform.errors.items())
             ])
             raise UploadException(
@@ -184,5 +209,5 @@ def ajax_upload(request, folder_id=None):
                     form_errors,))
     except UploadException as e:
         return HttpResponse(json.dumps({'error': str(e)}),
-                            status=500,
+                            # status=500, we know what's going on and must display it to the user
                             **response_params)

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -233,7 +233,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         from filer.utils.folders import get_default_folder_getter
         folder = get_default_folder_getter().get(folder_key, request)
         return self.directory_listing(request, folder.pk)
-    
+
     def directory_listing(self, request, folder_id=None, viewtype=None):
         clipboard = tools.get_user_clipboard(request.user)
         if viewtype == 'images_with_missing_data':

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -205,7 +205,9 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             url(r'^(?P<folder_id>\d+)/list/$',
                 self.admin_site.admin_view(self.directory_listing),
                 name='filer-directory_listing'),
-
+            url(r'^(?P<folder_key>[a-zA-Z][a-zA-Z0-9_]*)/list/$',
+                self.admin_site.admin_view(self.directory_listing_by_key),
+                name='filer-directory_listing_by_key'),
             url(r'^(?P<folder_id>\d+)/make_folder/$',
                 self.admin_site.admin_view(views.make_folder),
                 name='filer-directory_listing-make_folder'),
@@ -227,6 +229,11 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         return url_patterns
 
     # custom views
+    def directory_listing_by_key(self, request, folder_key):
+        from filer.utils.folders import get_default_folder_getter
+        folder = get_default_folder_getter().get(folder_key, request)
+        return self.directory_listing(request, folder.pk)
+    
     def directory_listing(self, request, folder_id=None, viewtype=None):
         clipboard = tools.get_user_clipboard(request.user)
         if viewtype == 'images_with_missing_data':

--- a/filer/fields/image.py
+++ b/filer/fields/image.py
@@ -18,4 +18,4 @@ class AdminImageFormField(AdminFileFormField):
 class FilerImageField(FilerFileField):
     default_form_class = AdminImageFormField
     default_model_class = Image
-    default_validators = [validate_images,]
+    default_validators = [validate_images, ]

--- a/filer/fields/image.py
+++ b/filer/fields/image.py
@@ -4,6 +4,7 @@ from filer.fields.file import (
     AdminFileWidget, AdminFileFormField, FilerFileField
 )
 from filer.models import Image
+from filer.validators import validate_images
 
 
 class AdminImageWidget(AdminFileWidget):
@@ -17,3 +18,4 @@ class AdminImageFormField(AdminFileFormField):
 class FilerImageField(FilerFileField):
     default_form_class = AdminImageFormField
     default_model_class = Image
+    default_validators = [validate_images,]

--- a/filer/private/sass/admin_filer.scss
+++ b/filer/private/sass/admin_filer.scss
@@ -19,6 +19,7 @@
 @import "components/navigator";
 @import "components/modal";
 @import "components/drag-and-drop";
+@import "components/direct-upload";
 
 //##############################################################################
 // IMPORT LIBS

--- a/filer/private/sass/components/_direct-upload.scss
+++ b/filer/private/sass/components/_direct-upload.scss
@@ -1,0 +1,19 @@
+.fileUploading {
+    .filerProgress{
+        display: inline-block !important;
+        margin: 2px 5px;
+    }
+}
+.filerUploader {
+    span{
+        display:inline-block;
+    }
+    > span{
+        position:relative;
+    }
+}
+.filerUploader > span input[type=file],
+.fileSelected .filerFilename,
+.fileUploading .filerChoose{
+    display:none;
+}

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -242,3 +242,4 @@ FILER_UPLOADER_CONNECTIONS = getattr(
 FILER_DUMP_PAYLOAD = getattr(settings, 'FILER_DUMP_PAYLOAD', False)  # Whether the filer shall dump the files payload
 
 FILER_CANONICAL_URL = getattr(settings, 'FILER_CANONICAL_URL', 'canonical/')
+FILER_DEFAULT_FOLDER_GETTER = getattr(settings, 'FILER_DEFAULT_FOLDER_GETTER', 'filer.utils.folders.DefaultFolderGetter')

--- a/filer/static/filer/js/addons/dropzone.init.js
+++ b/filer/static/filer/js/addons/dropzone.init.js
@@ -26,7 +26,7 @@
             element.toggleClass(mobileClass, element.width() < minWidth);
         };
         var showError = function (message) {
-            if(window.parent && window.parent.CMS){
+            if (window.parent && window.parent.CMS) {
                 try {
                     window.parent.CMS.API.Messages.open({
                         message: message
@@ -34,7 +34,7 @@
                 } catch (errorText) {
                     console.log(errorText);
                 }
-            }else{
+            } else {
                 alert(message);
             }
         };

--- a/filer/static/filer/js/addons/dropzone.init.js
+++ b/filer/static/filer/js/addons/dropzone.init.js
@@ -26,12 +26,16 @@
             element.toggleClass(mobileClass, element.width() < minWidth);
         };
         var showError = function (message) {
-            try {
-                window.parent.CMS.API.Messages.open({
-                    message: message
-                });
-            } catch (errorText) {
-                console.log(errorText);
+            if(window.parent && window.parent.CMS){
+                try {
+                    window.parent.CMS.API.Messages.open({
+                        message: message
+                    });
+                } catch (errorText) {
+                    console.log(errorText);
+                }
+            }else{
+                alert(message);
             }
         };
 

--- a/filer/static/filer/js/addons/widget.js
+++ b/filer/static/filer/js/addons/widget.js
@@ -21,8 +21,8 @@
         description.empty();
     };
 
-    $(document).ready(function(){
-        $('.filerFile').each(function(){
+    $(document).ready(function () {
+        $('.filerFile').each(function () {
             $(this).find('.vForeignKeyRawIdAdminField').hide();
             $('#add_' + $(this).data('id')).remove();
         });

--- a/filer/static/filer/js/addons/widget.js
+++ b/filer/static/filer/js/addons/widget.js
@@ -21,103 +21,13 @@
         description.empty();
     };
 
-    $(document).ready(function () {
-        $('.filerFile .vForeignKeyRawIdAdminField').attr('type', 'hidden');
+    $(document).ready(function(){
+        $('.filerFile').each(function(){
+            $(this).find('.vForeignKeyRawIdAdminField').hide();
+            $('#add_' + $(this).data('id')).remove();
+        });
         //if this file is included multiple time, we ensure that filer_clear is attached only once.
         $(document).off('click.filer', '.filerFile .filerClearer', filer_clear)
             .on('click.filer', '.filerFile .filerClearer', filer_clear);
     });
-})(django.jQuery);
-
-
-if(window.FormData){
-    (function($){
-    $(document).ready(function(){
-
-        $('.filerUploader > strong').remove();
-        $('.filerUploader > span').show();
-        var form = $('FORM .filerUploader').first().closest('form').get(0);
-        if(typeof form.filer_uploading === 'undefined'){
-            form.filer_uploading = 0 ;
-            $(form).submit(function(e){
-                if(this.filer_uploading > 0){
-                    e.preventDefault();
-                    if(this.filer_uploading == 1){
-                        msg = this.filerData.msg.wait_sing;
-                    }else{
-                        msg = this.filerData.msg.wait_plur.replace('%(nb_files)d', this.filer_uploading);
-                    }
-                    alert(msg);
-                }
-            });
-            $(document).on('click', '.filerUploader .filerChoose', function(e){
-                $(this).closest('.filerUploader').find('input[type=file]').trigger('click');
-            });
-            $(document).on('change', '.filerUploader input[type=file]', function(e){
-                var $this = $(this),
-                    container = $this.closest('.filerFile'),
-                    filerData = container.find('.filerChoose').data('filer'),
-                    el_filename = container.find('.filerFilename'),
-                    form = container.closest('form').get(0),
-                    name = this.value;
-
-                //add translations to the form.
-                if(!form.filerData){form.filerData = filerData;}
-
-                if(!name){
-                    el_filename.html(filerData.msg.no_file_selected);
-                }else{
-                    var startIndex = (name.indexOf('\\') >= 0 ? name.lastIndexOf('\\') : name.lastIndexOf('/')),
-                        url = filerData.url+'?qqfile='+name;
-                    if(filerData.folder_key){
-                        url+='&folder_key='+filerData.folder_key;
-                    }
-                    if(filerData.direct_upload_related_field){
-                        url+='&related_field='+filerData.direct_upload_related_field;
-                    }
-                    if(!form.filer_uploading){
-                        container.addClass('fileUploading') ;
-                    }
-                    name = name.substring(startIndex+1);
-                    el_filename.html(name);
-                    form.filer_uploading += 1 ;
-                    $.ajax({
-                         url:url,
-                         type: 'POST',
-                         data: this.files[0],
-                         cache: false,
-                         dataType: 'json',
-                         contentType: 'application/octet-stream',
-                         processData: false,
-                         context:container,
-                         success: function(data, textStatus, jqXHR){
-                            var base_id = '#' + this.find('.vForeignKeyRawIdAdminField').attr('id') ;
-                            if(typeof data.error === 'undefined'){
-                                $(base_id).attr('value', data.pk);
-                                $(base_id+'_thumbnail_img').attr('src', data.thumbnail);
-                                $(base_id+'_description_txt').html(data.label);
-                                $(base_id+'_clear').show();
-                                container.find('.filerFilename').html(filerData.msg.no_file_selected);
-                                container.addClass('fileSelected') ;
-                                container.find('.filerChoose').html(filerData.msg.choose_replace_file);
-                            }else{
-                                alert(data.error);
-                            }
-                            form.filer_uploading -= 1 ;
-                         },
-                         error: function(jqXHR, textStatus, errorThrown){
-                            alert(filerData.msg.error.replace('%(error)s', errorThrown));
-                            form.filer_uploading -= 1 ;
-                         },
-                         complete: function(jqXHR, textStatus){
-                            if(!form.filer_uploading){
-                                 container.removeClass('fileUploading') ;
-                            }
-                         }
-                    });
-                }
-            });
-        }
-    });
-    })(window.$ || django.jQuery);
-}
+})(window.$ || django.jQuery);

--- a/filer/static/filer/js/addons/widget.js
+++ b/filer/static/filer/js/addons/widget.js
@@ -28,3 +28,96 @@
             .on('click.filer', '.filerFile .filerClearer', filer_clear);
     });
 })(django.jQuery);
+
+
+if(window.FormData){
+    (function($){
+    $(document).ready(function(){
+
+        $('.filerUploader > strong').remove();
+        $('.filerUploader > span').show();
+        var form = $('FORM .filerUploader').first().closest('form').get(0);
+        if(typeof form.filer_uploading === 'undefined'){
+            form.filer_uploading = 0 ;
+            $(form).submit(function(e){
+                if(this.filer_uploading > 0){
+                    e.preventDefault();
+                    if(this.filer_uploading == 1){
+                        msg = this.filerData.msg.wait_sing;
+                    }else{
+                        msg = this.filerData.msg.wait_plur.replace('%(nb_files)d', this.filer_uploading);
+                    }
+                    alert(msg);
+                }
+            });
+            $(document).on('click', '.filerUploader .filerChoose', function(e){
+                $(this).closest('.filerUploader').find('input[type=file]').trigger('click');
+            });
+            $(document).on('change', '.filerUploader input[type=file]', function(e){
+                var $this = $(this),
+                    container = $this.closest('.filerFile'),
+                    filerData = container.find('.filerChoose').data('filer'),
+                    el_filename = container.find('.filerFilename'),
+                    form = container.closest('form').get(0),
+                    name = this.value;
+
+                //add translations to the form.
+                if(!form.filerData){form.filerData = filerData;}
+
+                if(!name){
+                    el_filename.html(filerData.msg.no_file_selected);
+                }else{
+                    var startIndex = (name.indexOf('\\') >= 0 ? name.lastIndexOf('\\') : name.lastIndexOf('/')),
+                        url = filerData.url+'?qqfile='+name;
+                    if(filerData.folder_key){
+                        url+='&folder_key='+filerData.folder_key;
+                    }
+                    if(filerData.direct_upload_related_field){
+                        url+='&related_field='+filerData.direct_upload_related_field;
+                    }
+                    if(!form.filer_uploading){
+                        container.addClass('fileUploading') ;
+                    }
+                    name = name.substring(startIndex+1);
+                    el_filename.html(name);
+                    form.filer_uploading += 1 ;
+                    $.ajax({
+                         url:url,
+                         type: 'POST',
+                         data: this.files[0],
+                         cache: false,
+                         dataType: 'json',
+                         contentType: 'application/octet-stream',
+                         processData: false,
+                         context:container,
+                         success: function(data, textStatus, jqXHR){
+                            var base_id = '#' + this.find('.vForeignKeyRawIdAdminField').attr('id') ;
+                            if(typeof data.error === 'undefined'){
+                                $(base_id).attr('value', data.pk);
+                                $(base_id+'_thumbnail_img').attr('src', data.thumbnail);
+                                $(base_id+'_description_txt').html(data.label);
+                                $(base_id+'_clear').show();
+                                container.find('.filerFilename').html(filerData.msg.no_file_selected);
+                                container.addClass('fileSelected') ;
+                                container.find('.filerChoose').html(filerData.msg.choose_replace_file);
+                            }else{
+                                alert(data.error);
+                            }
+                            form.filer_uploading -= 1 ;
+                         },
+                         error: function(jqXHR, textStatus, errorThrown){
+                            alert(filerData.msg.error.replace('%(error)s', errorThrown));
+                            form.filer_uploading -= 1 ;
+                         },
+                         complete: function(jqXHR, textStatus){
+                            if(!form.filer_uploading){
+                                 container.removeClass('fileUploading') ;
+                            }
+                         }
+                    });
+                }
+            });
+        }
+    });
+    })(window.$ || django.jQuery);
+}

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -17,38 +17,62 @@
         </div>
 
         <span class="filerFile js-file-selector">
-            {% if object %}
-                {% if object.icons.32 %}
-                    <a href="{{ object.url }}" target="_blank"><img id="{{ thumb_id }}" src="{{ object.icons.48 }}" alt="{{ object.label }}"></a>
-                    &nbsp;<span id="{{ span_id }}">{{ object.label }}</span>
+            {% block object_display %}
+                {% if object %}
+                    {% if object.icons.32 %}
+                        <a href="{{ object.url }}" target="_blank"><img id="{{ thumb_id }}" src="{{ object.icons.48 }}" alt="{{ object.label }}"></a>
+                        &nbsp;<span id="{{ span_id }}">{{ object.label }}</span>
+                    {% else %}
+                        <img id="{{ thumb_id }}" src="{% static 'filer/icons/missingfile_48x48.png' %}" alt="{% trans 'file missing' %}">
+                        &nbsp;<span id="{{ span_id }}">{% trans 'file missing' %}</span>
+                    {% endif %}
                 {% else %}
-                    <img id="{{ thumb_id }}" src="{% static 'filer/icons/missingfile_48x48.png' %}" alt="{% trans 'file missing' %}">
-                    &nbsp;<span id="{{ span_id }}">{% trans 'file missing' %}</span>
+                    <img id="{{ thumb_id }}" class="quiet hidden" alt="">
+                    &nbsp;<span id="{{ span_id }}"></span>
                 {% endif %}
-            {% else %}
-                <img id="{{ thumb_id }}" class="quiet hidden" alt="">
-                &nbsp;<span id="{{ span_id }}"></span>
-            {% endif %}
+            {% endblock object_display %}
 
-            <a href="{{ lookup_url }}" class="js-related-lookup related-lookup{% if object %} hidden{% endif %}" id="{{ id }}_lookup" data-id="{{ id }}" title="{% trans 'Lookup' %}"{% if not IS_DJANGO_18 %} onclick="return showRelatedObjectLookupPopup(this);"{% endif %}>
-                {% trans 'Choose File' %}
-            </a>
+            {% block object_change %}
+                {% if file_lookup_enabled %}
+                    <a href="{{ lookup_url }}" class="js-related-lookup related-lookup{% if object %} hidden{% endif %}" id="{{ id }}_lookup" data-id="{{ id }}" title="{% trans 'Lookup' %}"{% if not IS_DJANGO_18 %} onclick="return showRelatedObjectLookupPopup(this);"{% endif %}>
+                        {% trans 'Choose File' %}
+                    </a>
+                {% endif %}
+                {% if direct_upload_enabled %}
+                    <span id="{{ id }}_uploader" class="filerUploader">
+                        <strong>{% trans 'You must have a recent browser with javascript enabled to be able to use direct file upload'%}</strong>
+                        <span style="display:none;">
+                            <span class="filerFilename">{% trans 'No file selected' %}</span>
+                            <input type="file" name="{{ direct_upload_name }}" />
+                            <button class="filerChoose" type="button" data-filer="{{ json_opts }}">{% trans 'Choose a file' %}</button>
+                            <span class="filerProgress" style="display:none;">{% trans 'Uploading, please wait...' %}</span>
+                        </span>
+                    </span>
+                {% endif %}
+            {% endblock object_change %}
 
-            <img id="{{ clear_id }}" class="filerClearer" src="{% static 'admin/img/icon_deletelink.gif' %}" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %}>
+
+            {% block object_remove %}
+                <img id="{{ clear_id }}" class="filerClearer" src="{% static 'admin/img/icon_deletelink.gif' %}" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %}>
+            {% endblock object_remove %}
 
             <br>
 
             {{ hidden_input }}
-            <script type="text/javascript" id="{{id}}_javascript">
-                django.jQuery(document).ready(function(){
-                    var plus = django.jQuery('#add_{{ id }}');
-                    if (plus.length){
-                        plus.remove();
-                    }
-                    // Delete this javascript once loaded to avoid the "add new" link duplicates it
-                    django.jQuery('#{{id}}_javascript').remove();
-                });
-            </script>
+
+            {% block object_javascript %}
+                <script type="text/javascript" id="{{id}}_javascript">
+                    django.jQuery('#{{id}}').attr('type', 'hidden').attr('data-filer', 1);
+                    django.jQuery(document).ready(function(){
+                        var plus = django.jQuery('#add_{{ id }}');
+                        if (plus.length){
+                            plus.remove();
+                        }
+                        // Delete this javascript once loaded to avoid the "add new" link duplicates it
+                        django.jQuery('#{{id}}_javascript').remove();
+                    });
+                </script>
+            {% endblock object_javascript %}
         </span>
     </div>
 {% endspaceless %}

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -1,6 +1,8 @@
 {% load i18n filer_admin_tags staticfiles %}
 
 {% spaceless %}
+
+{% if direct_upload_enabled %}
     <div class="dz-preview dz-file-preview hidden js-filer-dropzone-template">
         <span class="filerFile">
             <div class="dz-thumbnail"><img class="quiet" data-dz-thumbnail></div>
@@ -10,74 +12,46 @@
         </span>
     </div>
 
-    <div class="js-filer-dropzone filer-dropzone{% if object %} js-object-attached{% endif %}" data-url="{% url 'admin:filer-ajax_upload' %}" data-max-file-size="20">
+    <div class="js-filer-dropzone filer-dropzone{% if object %} js-object-attached{% endif %}" data-url="{{ direct_upload_url }}" data-max-file-size="20">
         <div class="z-index-fix"></div>
         <div class="dz-default dz-message js-filer-dropzone-message{% if object %} hidden{% endif %}" id="{{ id }}_filer_dropzone_message">
-            <span class="icon fa fa-arrow-down"></span><span>{% trans "or drop your file here" %}</span>
+            <span class="icon fa fa-arrow-down"></span>
+            {% if file_lookup_enabled %}
+                <span>{% trans "or drop your file here" %}</span>
+            {% else %}
+                <span>{% trans "drop your file here" %}</span>
+            {% endif %}
         </div>
-
-        <span class="filerFile js-file-selector">
-            {% block object_display %}
-                {% if object %}
-                    {% if object.icons.32 %}
-                        <a href="{{ object.url }}" target="_blank"><img id="{{ thumb_id }}" src="{{ object.icons.48 }}" alt="{{ object.label }}"></a>
-                        &nbsp;<span id="{{ span_id }}">{{ object.label }}</span>
-                    {% else %}
-                        <img id="{{ thumb_id }}" src="{% static 'filer/icons/missingfile_48x48.png' %}" alt="{% trans 'file missing' %}">
-                        &nbsp;<span id="{{ span_id }}">{% trans 'file missing' %}</span>
-                    {% endif %}
+{% endif %}
+        <span class="filerFile js-file-selector" data-id="{{ id }}">
+            {% if object %}
+                {% if object.icons.32 %}
+                    <a href="{{ object.url }}" target="_blank"><img id="{{ thumb_id }}" src="{{ object.icons.48 }}" alt="{{ object.label }}"></a>
+                    &nbsp;<span id="{{ span_id }}">{{ object.label }}</span>
                 {% else %}
-                    <img id="{{ thumb_id }}" class="quiet hidden" alt="">
-                    &nbsp;<span id="{{ span_id }}"></span>
+                    <img id="{{ thumb_id }}" src="{% static 'filer/icons/missingfile_48x48.png' %}" alt="{% trans 'file missing' %}">
+                    &nbsp;<span id="{{ span_id }}">{% trans 'file missing' %}</span>
                 {% endif %}
-            {% endblock object_display %}
+            {% else %}
+                <img id="{{ thumb_id }}" class="quiet hidden" alt="">
+                &nbsp;<span id="{{ span_id }}"></span>
+            {% endif %}
 
-            {% block object_change %}
-                {% if file_lookup_enabled %}
-                    <a href="{{ lookup_url }}" class="js-related-lookup related-lookup{% if object %} hidden{% endif %}" id="{{ id }}_lookup" data-id="{{ id }}" title="{% trans 'Lookup' %}"{% if not IS_DJANGO_18 %} onclick="return showRelatedObjectLookupPopup(this);"{% endif %}>
-                        {% trans 'Choose File' %}
-                    </a>
-                {% endif %}
-                {% if direct_upload_enabled %}
-                    <span id="{{ id }}_uploader" class="filerUploader">
-                        <strong>{% trans 'You must have a recent browser with javascript enabled to be able to use direct file upload'%}</strong>
-                        <span style="display:none;">
-                            <span class="filerFilename">{% trans 'No file selected' %}</span>
-                            <input type="file" name="{{ direct_upload_name }}" />
-                            <button class="filerChoose" type="button" data-filer="{{ json_opts }}">{% trans 'Choose a file' %}</button>
-                            <span class="filerProgress" style="display:none;">{% trans 'Uploading, please wait...' %}</span>
-                        </span>
-                    </span>
-                {% endif %}
-            {% endblock object_change %}
+            {% if file_lookup_enabled %}
+                <a href="{{ lookup_url }}" class="js-related-lookup related-lookup{% if object %} hidden{% endif %}" id="{{ id }}_lookup" data-id="{{ id }}" title="{% trans 'Lookup' %}"{% if not IS_DJANGO_18 %} onclick="return showRelatedObjectLookupPopup(this);"{% endif %}>
+                    {% trans 'Choose File' %}
+                </a>
+            {% endif %}
 
-
-            {% block object_remove %}
-                <img id="{{ clear_id }}" class="filerClearer" src="{% static 'admin/img/icon_deletelink.gif' %}" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %}>
-            {% endblock object_remove %}
+            <img id="{{ clear_id }}" class="filerClearer" src="{% static 'admin/img/icon_deletelink.gif' %}" width="10" height="10" alt="{% trans 'Clear' %}" title="{% trans 'Clear' %}"{% if not object %} style="display: none;"{% endif %}>
 
             <br>
 
             {{ hidden_input }}
-
-            {% block object_javascript %}
-                <script type="text/javascript" id="{{id}}_javascript">
-                    django.jQuery('#{{id}}').attr('type', 'hidden').attr('data-filer', 1);
-                    django.jQuery(document).ready(function(){
-                        var plus = django.jQuery('#add_{{ id }}');
-                        if (plus.length){
-                            plus.remove();
-                        }
-                        // Delete this javascript once loaded to avoid the "add new" link duplicates it
-                        django.jQuery('#{{id}}_javascript').remove();
-                    });
-                </script>
-            {% endblock object_javascript %}
         </span>
-    </div>
-{% endspaceless %}
 
-<link rel="stylesheet" type="text/css" href="{% static 'filer/css/admin_filer.css' %}">
-<script src="{% static 'filer/js/libs/jquery.min.js' %}"></script>
-<script src="{% static 'filer/js/libs/dropzone.min.js' %}"></script>
-<script src="{% static 'filer/js/addons/dropzone.init.js' %}"></script>
+{% if direct_upload_enabled %}
+    </div>
+{% endif %}
+
+{% endspaceless %}

--- a/filer/test_utils/thirdparty_app/admin.py
+++ b/filer/test_utils/thirdparty_app/admin.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.contrib import admin
+
+from filer.test_utils.thirdparty_app.models import Example
+
+class ExampleAdmin(admin.ModelAdmin):
+    pass
+
+admin.site.register(Example, ExampleAdmin)

--- a/filer/test_utils/thirdparty_app/admin.py
+++ b/filer/test_utils/thirdparty_app/admin.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 
 from filer.test_utils.thirdparty_app.models import Example
 
+
 class ExampleAdmin(admin.ModelAdmin):
     pass
 

--- a/filer/test_utils/thirdparty_app/handlers.py
+++ b/filer/test_utils/thirdparty_app/handlers.py
@@ -1,0 +1,28 @@
+#-*- coding: utf-8 -*-
+
+from filer.models import Folder
+from filer.utils.folders import DefaultFolderGetter
+
+class CustomFolderGetter(DefaultFolderGetter):
+
+    @classmethod
+    def USER_OWN_FOLDER(cls, request):
+        user = request.user
+        if not user.is_authenticated():
+            return None
+        return cls._get_or_create(name=user.username, owner=user, parent_kwargs={
+            'name': 'users_files', 'parent':None})
+
+    @classmethod
+    def IMAGES(cls, request):
+        user = request.user
+        if not user.is_authenticated():
+            return None
+        return cls._get_or_create(name='Images')
+
+    @classmethod
+    def DOCUMENTS(cls, request):
+        user = request.user
+        if not user.is_authenticated():
+            return None
+        return cls._get_or_create(name='Documents')

--- a/filer/test_utils/thirdparty_app/handlers.py
+++ b/filer/test_utils/thirdparty_app/handlers.py
@@ -1,7 +1,7 @@
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
-from filer.models import Folder
 from filer.utils.folders import DefaultFolderGetter
+
 
 class CustomFolderGetter(DefaultFolderGetter):
 
@@ -10,8 +10,9 @@ class CustomFolderGetter(DefaultFolderGetter):
         user = request.user
         if not user.is_authenticated():
             return None
-        return cls._get_or_create(name=user.username, owner=user, parent_kwargs={
-            'name': 'users_files', 'parent':None})
+        return cls._get_or_create(name=user.username,
+                                  owner=user,
+                                  parent_kwargs={'name': 'users_files', 'parent': None})
 
     @classmethod
     def IMAGES(cls, request):

--- a/filer/test_utils/thirdparty_app/migrations/0001_initial.py
+++ b/filer/test_utils/thirdparty_app/migrations/0001_initial.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from filer.settings import FILER_IMAGE_MODEL
+import filer.fields.file
+import filer.fields.image
+import filer.validators
+
+
+class Migration(migrations.Migration):
+
+    if FILER_IMAGE_MODEL:
+        dependencies = [
+            ('filer', '0002_auto_20150606_2003'), 
+            ('custom_image', '0001_initial'),
+        ]
+    else:
+        dependencies = [
+            ('filer', '0002_auto_20150606_2003'), 
+        ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Example',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.CharField(max_length=100, verbose_name='title')),
+                ('document_choose_or_browse', filer.fields.image.FilerImageField(related_name='documents+', validators=[filer.validators.FileMimetypeValidator(['application/msword', 'application/pdf', 'application/vnd.ms-excel', 'application/vnd.ms-powerpoint', 'application/vnd.oasis.opendocument.text', 'application/vnd.oasis.opendocument.spreadsheet', 'application/vnd.oasis.opendocument.presentation', 'text/csv'])], to='filer.Image', blank=True, help_text='CSV, PDF, ODT, DOC...', null=True, verbose_name='document')),
+                ('file_choose_only', filer.fields.file.FilerFileField(related_name='files+', verbose_name='file', blank=True, to='filer.File', null=True)),
+                ('illustration_browse_only', filer.fields.image.FilerImageField(related_name='illustrations+', verbose_name='illustration', blank=True, to='filer.Image', null=True)),
+            ],
+            options={
+                'verbose_name': 'example',
+                'verbose_name_plural': 'examples',
+            },
+            bases=(models.Model,),
+        ),
+        migrations.CreateModel(
+            name='ExampleGalleryElement',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('order', models.PositiveIntegerField(default=0, verbose_name='order', blank=True)),
+                ('example', models.ForeignKey(related_name='gallery_elements', verbose_name='example', to='thirdparty_app.Example')),
+                ('image', filer.fields.image.FilerImageField(related_name='images+', validators=[filer.validators.FileMimetypeValidator(['image/svg+xml', 'image/jpeg', 'image/png', 'image/gif'])], to='filer.Image', blank=True, null=True, verbose_name='image')),
+            ],
+            options={
+                'ordering': ('example__pk', 'order'),
+                'verbose_name': 'gallery',
+                'verbose_name_plural': 'galleries',
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/filer/test_utils/thirdparty_app/models.py
+++ b/filer/test_utils/thirdparty_app/models.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from filer.fields.file import FilerFileField
 from filer.fields.image import FilerImageField
@@ -14,24 +13,24 @@ class Example(models.Model):
         verbose_name='title',
         max_length=100,)
     illustration_browse_only = FilerImageField(
-        verbose_name='illustration', 
-        default_direct_upload_enabled=True, #add a "browse" button with ajax upload
-        default_file_lookup_enabled=False,#remove the "choose" link
+        verbose_name='illustration',
+        default_direct_upload_enabled=True,  # add a "browse" button with ajax upload
+        default_file_lookup_enabled=False,  # remove the "choose" link
         default_folder_key='IMAGES',
         null=True, blank=True,
         related_name='illustrations+',)
     file_choose_only = FilerFileField(
-        verbose_name='file', 
-        default_direct_upload_enabled=False, #remove the "browse" button with ajax upload
-        default_file_lookup_enabled=True,#add a "choose" link
+        verbose_name='file',
+        default_direct_upload_enabled=False,  # remove the "browse" button with ajax upload
+        default_file_lookup_enabled=True,  # add a "choose" link
         default_folder_key='USER_OWN_FOLDER',
         null=True, blank=True,
         related_name='files+',)
     document_choose_or_browse = FilerFileField(
-        verbose_name='document', 
+        verbose_name='document',
         help_text='CSV, PDF, ODT, DOC...',
-        default_direct_upload_enabled=True, #add a "browse" button with ajax upload
-        default_file_lookup_enabled=True,#add a "choose" link
+        default_direct_upload_enabled=True,  # add a "browse" button with ajax upload
+        default_file_lookup_enabled=True,  # add a "choose" link
         default_folder_key='DOCUMENTS',
         validators=[validate_documents, ],
         null=True, blank=True,
@@ -53,9 +52,9 @@ class ExampleGalleryElement(models.Model):
         default=0,
     )
     image = FilerImageField(
-        verbose_name='image', 
-        default_direct_upload_enabled=True, #add a "browse" button with ajax upload
-        default_file_lookup_enabled=False,#remove the "choose" link
+        verbose_name='image',
+        default_direct_upload_enabled=True,  # add a "browse" button with ajax upload
+        default_file_lookup_enabled=False,  # remove the "choose" link
         default_folder_key='IMAGES',
         null=True, blank=True,
         validators=[validate_html5_images, ],

--- a/filer/test_utils/thirdparty_app/models.py
+++ b/filer/test_utils/thirdparty_app/models.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
+
+from filer.fields.file import FilerFileField
+from filer.fields.image import FilerImageField
+from filer.validators import validate_documents, validate_html5_images
+
+
+class Example(models.Model):
+    title = models.CharField(
+        verbose_name='title',
+        max_length=100,)
+    illustration_browse_only = FilerImageField(
+        verbose_name='illustration', 
+        default_direct_upload_enabled=True, #add a "browse" button with ajax upload
+        default_file_lookup_enabled=False,#remove the "choose" link
+        default_folder_key='IMAGES',
+        null=True, blank=True,
+        related_name='illustrations+',)
+    file_choose_only = FilerFileField(
+        verbose_name='file', 
+        default_direct_upload_enabled=False, #remove the "browse" button with ajax upload
+        default_file_lookup_enabled=True,#add a "choose" link
+        default_folder_key='USER_OWN_FOLDER',
+        null=True, blank=True,
+        related_name='files+',)
+    document_choose_or_browse = FilerFileField(
+        verbose_name='document', 
+        help_text='CSV, PDF, ODT, DOC...',
+        default_direct_upload_enabled=True, #add a "browse" button with ajax upload
+        default_file_lookup_enabled=True,#add a "choose" link
+        default_folder_key='DOCUMENTS',
+        validators=[validate_documents, ],
+        null=True, blank=True,
+        related_name='documents+',)
+
+    class Meta:
+        app_label = 'thirdparty_app'
+        verbose_name = 'example'
+        verbose_name_plural = 'examples'
+
+    def __str__(self):
+        return '%s' % self.title
+
+
+class ExampleGalleryElement(models.Model):
+    order = models.PositiveIntegerField(
+        verbose_name='order',
+        blank=True, null=False,
+        default=0,
+    )
+    image = FilerImageField(
+        verbose_name='image', 
+        default_direct_upload_enabled=True, #add a "browse" button with ajax upload
+        default_file_lookup_enabled=False,#remove the "choose" link
+        default_folder_key='IMAGES',
+        null=True, blank=True,
+        validators=[validate_html5_images, ],
+        related_name='images+',)
+    example = models.ForeignKey(Example,
+        verbose_name='example',
+        related_name='gallery_elements',)
+
+    class Meta:
+        app_label = 'thirdparty_app'
+        ordering = ('example__pk', 'order',)
+        verbose_name = 'gallery'
+        verbose_name_plural = 'galleries'

--- a/filer/test_utils/thirdparty_app/south_migrations/0001_initial.py
+++ b/filer/test_utils/thirdparty_app/south_migrations/0001_initial.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+from filer.settings import FILER_IMAGE_MODEL
+
+
+class Migration(SchemaMigration):
+
+    if FILER_IMAGE_MODEL:
+        depends_on = (
+            ("filer", "0014_auto__add_field_image_related_url__chg_field_file_name"),
+            ("custom_image", "0001_initial"),
+        )
+        
+    else:
+        depends_on = (
+            ("filer", "0014_auto__add_field_image_related_url__chg_field_file_name"),
+        )
+    
+
+    def forwards(self, orm):
+        # Adding model 'Example'
+        db.create_table(u'thirdparty_app_example', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=100)),
+            ('illustration_browse_only', self.gf(u'django.db.models.fields.related.ForeignKey')(blank=True, related_name=u'illustrations+', null=True, to=orm['filer.Image'])),
+            ('file_choose_only', self.gf(u'django.db.models.fields.related.ForeignKey')(blank=True, related_name=u'files+', null=True, to=orm['filer.File'])),
+            ('document_choose_or_browse', self.gf(u'django.db.models.fields.related.ForeignKey')(blank=True, related_name=u'documents+', null=True, to=orm['filer.Image'])),
+        ))
+        db.send_create_signal(u'thirdparty_app', ['Example'])
+
+        # Adding model 'ExampleGalleryElement'
+        db.create_table(u'thirdparty_app_examplegalleryelement', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('order', self.gf('django.db.models.fields.PositiveIntegerField')(default=0, blank=True)),
+            ('image', self.gf(u'django.db.models.fields.related.ForeignKey')(blank=True, related_name=u'images+', null=True, to=orm['filer.Image'])),
+            ('example', self.gf('django.db.models.fields.related.ForeignKey')(related_name=u'gallery_elements', to=orm['thirdparty_app.Example'])),
+        ))
+        db.send_create_signal(u'thirdparty_app', ['ExampleGalleryElement'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Example'
+        db.delete_table(u'thirdparty_app_example')
+
+        # Deleting model 'ExampleGalleryElement'
+        db.delete_table(u'thirdparty_app_examplegalleryelement')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'filer.file': {
+            'Meta': {'object_name': 'File'},
+            '_file_size': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'folder': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'all_files'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            'has_all_mandatory_data': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '255', 'blank': 'True'}),
+            'original_filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'owned_files'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'polymorphic_ctype': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'polymorphic_filer.file_set+'", 'null': 'True', 'to': u"orm['contenttypes.ContentType']"}),
+            'sha1': ('django.db.models.fields.CharField', [], {'default': "u''", 'max_length': '40', 'blank': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'filer.folder': {
+            'Meta': {'ordering': "(u'name',)", 'unique_together': "((u'parent', u'name'),)", 'object_name': 'Folder'},
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'modified_at': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'owner': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'filer_owned_folders'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'children'", 'null': 'True', 'to': u"orm['filer.Folder']"}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'uploaded_at': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        'filer.image': {
+            'Meta': {'object_name': 'Image'},
+            '_height': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            '_width': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'date_taken': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'default_alt_text': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'default_caption': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'file_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['filer.File']", 'unique': 'True', 'primary_key': 'True'}),
+            'must_always_publish_author_credit': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'must_always_publish_copyright': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subject_location': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '64', 'null': 'True', 'blank': 'True'})
+        },
+        u'thirdparty_app.example': {
+            'Meta': {'object_name': 'Example'},
+            'document_choose_or_browse': (u'django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'documents+'", 'null': 'True', 'to': "orm['filer.Image']"}),
+            'file_choose_only': (u'django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'files+'", 'null': 'True', 'to': u"orm['filer.File']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'illustration_browse_only': (u'django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'illustrations+'", 'null': 'True', 'to': "orm['filer.Image']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'thirdparty_app.examplegalleryelement': {
+            'Meta': {'ordering': "(u'example__pk', u'order')", 'object_name': 'ExampleGalleryElement'},
+            'example': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'gallery_elements'", 'to': u"orm['thirdparty_app.Example']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': (u'django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "u'images+'", 'null': 'True', 'to': "orm['filer.Image']"}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['thirdparty_app']

--- a/filer/tests/__init__.py
+++ b/filer/tests/__init__.py
@@ -1,6 +1,7 @@
 #-*- coding: utf-8 -*-
 from filer.tests.admin import *
 from filer.tests.dump import *
+from filer.tests.misc import *
 from filer.tests.models import *
 from filer.tests.permissions import *
 from filer.tests.server_backends import *

--- a/filer/tests/admin.py
+++ b/filer/tests/admin.py
@@ -83,6 +83,12 @@ class FilerFolderAdminUrlsTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['folder'].children.count(), 6)
 
+    def test_filer_directory_listing_by_key(self):
+        response = self.client.get(reverse(
+            'admin:filer-directory_listing_by_key', kwargs={'folder_key':'DOCUMENTS'}))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['folder'].name, 'Documents')
+
     def test_validate_no_duplcate_folders(self):
         FOLDER_NAME = "root folder 1"
         self.assertEqual(Folder.objects.count(), 0)

--- a/filer/tests/misc.py
+++ b/filer/tests/misc.py
@@ -1,0 +1,170 @@
+#-*- coding: utf-8 -*-
+
+import json
+from lxml import html
+import os
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.files import File as DjangoFile
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test.client import RequestFactory
+
+from filer import settings as filer_settings
+from filer.models import File, Folder, Image
+from filer.tests.helpers import create_superuser, create_image
+from filer.utils.folders import DefaultFolderGetter, get_default_folder_getter
+from filer.validators import FileMimetypeValidator, validate_documents, validate_images
+from filer.test_utils.thirdparty_app.models import Example
+
+
+class FilerTestMixin(object):
+    def setUp(self):
+        super(FilerTestMixin, self).setUp()
+        self.superuser = create_superuser()
+        self.client.login(username='admin', password='secret')
+        self.img = create_image()
+        self.image_name = 'test_file.jpg'
+        self.filename = os.path.join(settings.FILE_UPLOAD_TEMP_DIR, self.image_name)
+        self.img.save(self.filename, 'JPEG')
+        self.usersfolder, self.usersfolder_created = Folder.objects.get_or_create(
+            name='users_files', parent=None, defaults={'owner': self.superuser,})
+
+    def tearDown(self):
+        File.objects.delete()
+        if self.usersfolder_created:
+            self.usersfolder.delete()
+        self.client.logout()
+
+
+class FilerDynamicFolderTest(FilerTestMixin, TestCase):
+
+    def test_filer_dynamic_folder_creation(self):
+        rf = RequestFactory()
+        request = rf.get("/")
+        request.session = {}
+        request.user = self.superuser
+        folder = get_default_folder_getter().get('USER_OWN_FOLDER', request)
+        self.assertEqual(folder.name, self.superuser.username)
+
+    def test_filer_dynamic_folder_ajax_upload_file(self):
+        self.assertEqual(Image.objects.count(), 0)
+        file_obj = DjangoFile(open(self.filename, 'rb'))
+        url = reverse('filer:direct_upload')
+        url += '?qqfile=%s&folder_key=%s' % (self.image_name, 'USER_OWN_FOLDER')
+        response = self.client.post(
+            url, data=file_obj.read(), content_type='application/octet-stream',
+            **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
+        )
+        self.assertEqual(Image.objects.count(), 1)
+        img = Image.objects.all()[0]
+        self.assertEqual(img.original_filename, self.image_name)
+        self.assertEqual(img.folder.name, self.superuser.username)
+        self.assertEqual(img.folder.parent_id, self.usersfolder.pk)
+
+
+class FilerMimetypeLimitationTest(FilerTestMixin, TestCase):
+
+    def setUp(self):
+        super(FilerMimetypeLimitationTest, self).setUp()
+        file_obj = DjangoFile(open(self.filename, 'rb'), name=self.image_name)
+        self.image = Image.objects.create(
+            owner=self.superuser,
+            is_public=True,
+            original_filename=self.image_name,
+            file=file_obj
+        )
+
+    def test_filer_specific_mimetype_validator(self):
+        jpeg_validator = FileMimetypeValidator(['image/jpeg',])
+        try:
+            jpeg_validator(self.image.pk)
+        except ValidationError:
+            self.failfast("FileMimetypeValidator() raised ValidationError unexpectedly !")
+
+        png_validator = FileMimetypeValidator(['image/png',])
+        with self.assertRaises(ValidationError):
+            png_validator(self.image.pk)
+
+    def test_filer_generic_mimetype_validator(self):
+        try:
+            validate_images(self.image.pk)
+        except ValidationError:
+            self.failfast("FileMimetypeValidator() raised ValidationError unexpectedly !")
+
+        with self.assertRaises(ValidationError):
+            validate_documents(self.image.pk)
+
+    def test_filer_partial_ajax_upload_mimetype_validator(self):
+        self.assertEqual(File.objects.count(), 1)
+        file_obj = DjangoFile(open(self.filename, 'rb'))
+        url = reverse('filer:direct_upload')
+        url += '?qqfile=other.jpeg&related_field=thirdparty_app.Example.illustration_browse_only'
+        response = self.client.post(
+            url, data=file_obj.read(), content_type='application/octet-stream',
+            **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(File.objects.count(), 2)
+        self.assertEqual(Image.objects.count(), 2)
+
+        file_obj.seek(0)
+        url = reverse('filer:direct_upload')
+        url += '?qqfile=again.jpeg&related_field=thirdparty_app.Example.document_choose_or_browse'
+        response = self.client.post(
+            url, data=file_obj.read(), content_type='application/octet-stream',
+            **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(File.objects.count(), 2)
+        data = json.loads(response.content.decode())
+        self.assertTrue(bool(data.get('error')))
+
+
+class FilerWidgetTest(FilerTestMixin, TestCase):
+
+    def test_filer_widget_choose_and_or_browse(self):
+        url = reverse('admin:thirdparty_app_example_add')
+        response = self.client.get(url)
+        dom = html.fromstring(response.content)
+
+        ids = [
+            el.attrib['id'] for el in dom.xpath('//a[@class="related-lookup"]')]
+        expected_choose_ids = [
+            'lookup_id_file_choose_only', 'lookup_id_document_choose_or_browse']
+        self.assertEqual(ids, expected_choose_ids)
+
+        ids = [
+            el.attrib['id'] for el in dom.xpath('//span[@class="filerUploader"]')]
+        expected_browse_ids = [
+            'id_illustration_browse_only_uploader', 'id_document_choose_or_browse_uploader']
+        self.assertEqual(ids, expected_browse_ids)
+
+
+    def test_filer_widget_folder_key(self):
+        url = reverse('admin:thirdparty_app_example_add')
+        response = self.client.get(url)
+        dom = html.fromstring(response.content)
+
+        for field_name in ('file_choose_only', 'document_choose_or_browse'):
+            field = Example._meta.get_field_by_name(field_name)[0]
+            folder_key = field.default_formfield_kwargs.get('folder_key')
+            expected_href = reverse(
+                'admin:filer-directory_listing_by_key', kwargs={'folder_key':folder_key})
+            try:
+                href = dom.get_element_by_id('lookup_id_%s' % field_name).attrib['href']
+            except (KeyError, IndexError):
+                self.fail('DOM for "%s" field is not as expected.' % field_name)[0]
+            href = href.split('?')[0]
+            self.assertEqual(href, expected_href)
+
+        for field_name in ('illustration_browse_only', 'document_choose_or_browse'):
+            field = Example._meta.get_field_by_name(field_name)[0]
+            folder_key = field.default_formfield_kwargs.get('folder_key')
+            try:
+                uploader = dom.get_element_by_id('id_%s_uploader' % field_name)
+                data = json.loads(uploader.find_class('filerChoose')[0].attrib['data-filer'])
+            except (KeyError, IndexError):
+                self.fail('DOM for "%s" field is not as expected.' % field_name)
+            self.assertEqual(folder_key, data.get('folder_key'))

--- a/filer/urls.py
+++ b/filer/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
         views.canonical,
         name='canonical'
     ),
+    url(r'^direct_upload/$', ajax_upload, name='direct_upload',),
 ]

--- a/filer/urls.py
+++ b/filer/urls.py
@@ -11,5 +11,4 @@ urlpatterns = [
         views.canonical,
         name='canonical'
     ),
-    url(r'^direct_upload/$', ajax_upload, name='direct_upload',),
 ]

--- a/filer/utils/compatibility.py
+++ b/filer/utils/compatibility.py
@@ -5,6 +5,12 @@ import django
 from django.utils import six
 
 try:
+    from django.apps import apps
+    get_model = apps.get_model
+except ImportError:
+    from django.db.models import get_model
+
+try:
     from django.utils.text import truncate_words
 except ImportError:
     # django >=1.5

--- a/filer/utils/folders.py
+++ b/filer/utils/folders.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from filer import settings as filer_settings
+from filer.models import Folder
+from filer.utils.loader import load_object
+
+
+def get_default_folder_getter():
+    path = filer_settings.FILER_DEFAULT_FOLDER_GETTER
+    if path:
+        if path == 'filer.utils.folders.DefaultFolderGetter':
+            return DefaultFolderGetter
+        return load_object(path)
+    raise Exception('FILER_DEFAULT_FOLDER_GETTER improperly configured')
+
+
+class DefaultFolderGetter(object):
+    """
+    Default Folder getter to configure some "dynamic" folders
+    You just have to add a method named as the key attr. exemple :
+
+    @classmethod
+    def USER_OWN_FOLDER(cls, request):
+        if not request.user.is_authenticated():
+            return None
+        parent_kwargs = {
+            name: 'users_files',
+            
+        }
+        return cls._get_or_create(name=user.username, owner=user, parent_kwargs=parent_kwargs)
+    """
+
+    @classmethod
+    def _get_or_create(cls, name, owner=None, parent_kwargs=None):
+        filters = {}
+        if parent_kwargs:
+            parent_folder, created = Folder.objects.get_or_create(**parent_kwargs)
+            filters['parent_id'] = parent_folder.pk
+        else:
+            filters['parent_id__isnull'] = True
+        if owner:
+            filters['owner'] = owner
+        folder = Folder.objects.filter(**filters)[0:1]
+        if not folder:
+            folder = Folder()
+            folder.name = name
+            if parent_kwargs:
+                folder.parent_id = parent_folder.pk
+            if owner:
+                folder.owner = owner
+            folder.save()
+        else:
+            folder = folder[0]
+        return folder
+
+    @classmethod
+    def get(cls, key, request):
+        if hasattr(cls, key):
+            getter = getattr(cls, key)
+            if callable(getter):
+                return getter(request)
+        return None

--- a/filer/utils/folders.py
+++ b/filer/utils/folders.py
@@ -26,14 +26,14 @@ class DefaultFolderGetter(object):
             return None
         parent_kwargs = {
             name: 'users_files',
-            
+
         }
         return cls._get_or_create(name=user.username, owner=user, parent_kwargs=parent_kwargs)
     """
 
     @classmethod
     def _get_or_create(cls, name, owner=None, parent_kwargs=None):
-        filters = {}
+        filters = {'name': name}
         if parent_kwargs:
             parent_folder, created = Folder.objects.get_or_create(**parent_kwargs)
             filters['parent_id'] = parent_folder.pk

--- a/filer/validators.py
+++ b/filer/validators.py
@@ -1,8 +1,9 @@
-# -*- coding: utf-8 -*-
+#  -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 try:
     from magic import from_buffer
+
     def get_mime_type(fp):
         return from_buffer(fp.read(1024), mime=True)
 except ImportError:
@@ -12,8 +13,9 @@ except ImportError:
         'Mime detection will be based on file\'s extension : this is not safe at all.'
         'Please install python-magic for better mime type detection based on file\'s content.'
     ))
-    
+
     from mimetypes import guess_type
+
     def get_mime_type(fp):
         (mime, encoding) = guess_type(fp.name, strict=False)
         return mime
@@ -27,6 +29,7 @@ except ImportError:
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
+
 @deconstructible
 class FileMimetypeValidator(object):
     """
@@ -34,7 +37,7 @@ class FileMimetypeValidator(object):
     Value can be :
         * an integer : pk of the File instance to validate
         * a File instance
-        * a File instance #TODO : File ?
+        * a File instance  # TODO : File ?
         * a ChunkFile File instance (part of a file during the upload process)
     raises ValidationError if file's mimetype is not valid
     """
@@ -53,8 +56,8 @@ class FileMimetypeValidator(object):
                 raise ValidationError(_('This value is not a valid file'))
             fp = f.file
         elif hasattr(value, 'name') and hasattr(value, 'read') and callable(value.read):
-            #we only need .name and .read(). If this object have this attr and this method, 
-            #it's ok
+            # we only need .name and .read(). If this object have this attr and this method,
+            # it's ok
             fp = value
         elif hasattr(value, 'file'):
             fp = value.file
@@ -82,33 +85,43 @@ class FileMimetypeValidator(object):
         return self.mimetypes == other.mimetypes
 
 
-validate_images = FileMimetypeValidator(['image/*',])
-validate_videos = FileMimetypeValidator(['video/*',])
-validate_audios = FileMimetypeValidator(['audio/*',])
+validate_images = FileMimetypeValidator(['image/*', ])
+validate_videos = FileMimetypeValidator(['video/*', ])
+validate_audios = FileMimetypeValidator(['audio/*', ])
 
 validate_documents = FileMimetypeValidator([
-    #Main document mimetypes for CSV, DOC, XLS, PPT, ODT, ODS, ODP, PDF
-    'application/msword', 
+    # Main document mimetypes for CSV, DOC, XLS, PPT, ODT, ODS, ODP, PDF
+    'application/msword',
     'application/pdf',
-    'application/vnd.ms-excel', 
+    'application/vnd.ms-excel',
     'application/vnd.ms-powerpoint',
-    'application/vnd.oasis.opendocument.text', 
+    'application/vnd.oasis.opendocument.text',
     'application/vnd.oasis.opendocument.spreadsheet',
     'application/vnd.oasis.opendocument.presentation',
-    'text/csv',])
+    'text/csv',
+])
 
 validate_html5_images = FileMimetypeValidator([
-    #Main supported mime types for web image content : SVG, JPEG, PNG, GIF
-    'image/svg+xml', #http://caniuse.com/#feat=svg
-    'image/jpeg', 'image/png', 'image/gif'])
+    # Main supported mime types for web image content : SVG, JPEG, PNG, GIF
+    'image/svg+xml',  # http://caniuse.com/#feat=svg
+    'image/jpeg',
+    'image/png',
+    'image/gif'
+])
 
 validate_html5_videos = FileMimetypeValidator([
-    #Main supported mime types for web video content : OGV, MP4, WEBM
-    'video/ogg', #http://caniuse.com/#search=ogg
-    'video/mp4', #http://caniuse.com/#search=mp4
-    'video/webm',#http://caniuse.com/#search=webm
-    ])
+    # Main supported mime types for web video content : OGV, MP4, WEBM
+    'video/ogg',   # http://caniuse.com/#search=ogg
+    'video/mp4',   # http://caniuse.com/#search=mp4
+    'video/webm',  # http://caniuse.com/#search=webm
+])
 
 validate_html5_audios = FileMimetypeValidator([
-    #Main supported mime types for web audio content : AAC, OGG, MP4, MP3, WAV, WEBM
-    'audio/aac', 'audio/ogg', 'audio/mp4', 'audio/mpeg', 'audio/wav', 'audio/webm',])
+    # Main supported mime types for web audio content : AAC, OGG, MP4, MP3, WAV, WEBM
+    'audio/aac',
+    'audio/ogg',
+    'audio/mp4',
+    'audio/mpeg',
+    'audio/wav',
+    'audio/webm',
+])

--- a/filer/validators.py
+++ b/filer/validators.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+try:
+    from magic import from_buffer
+    def get_mime_type(fp):
+        return from_buffer(fp.read(1024), mime=True)
+except ImportError:
+    import warnings
+    warnings.warn((
+        'Can not import python-magic. '
+        'Mime detection will be based on file\'s extension : this is not safe at all.'
+        'Please install python-magic for better mime type detection based on file\'s content.'
+    ))
+    
+    from mimetypes import guess_type
+    def get_mime_type(fp):
+        (mime, encoding) = guess_type(fp.name, strict=False)
+        return mime
+
+try:
+    from django.utils.deconstruct import deconstructible
+except ImportError:
+    def deconstructible(cls):
+        return cls
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
+
+@deconstructible
+class FileMimetypeValidator(object):
+    """
+    Validates that a file has a correct mimetype.
+    Value can be :
+        * an integer : pk of the File instance to validate
+        * a File instance
+        * a File instance #TODO : File ?
+        * a ChunkFile File instance (part of a file during the upload process)
+    raises ValidationError if file's mimetype is not valid
+    """
+    def __init__(self, mimetypes):
+        self.mimetypes = mimetypes
+
+    def __call__(self, value):
+        if not value:
+            return
+
+        if type(value) == int:
+            from filer.models import File
+            try:
+                f = File.objects.get(pk=value)
+            except File.DoesNotExist:
+                raise ValidationError(_('This value is not a valid file'))
+            fp = f.file
+        elif hasattr(value, 'name') and hasattr(value, 'read') and callable(value.read):
+            #we only need .name and .read(). If this object have this attr and this method, 
+            #it's ok
+            fp = value
+        elif hasattr(value, 'file'):
+            fp = value.file
+        else:
+            raise ValidationError(_('This value is not a valid file'))
+
+        try:
+            mime = get_mime_type(fp)
+        except AttributeError:
+            mime = None
+
+        if not mime:
+            raise ValidationError(_('This value is not a valid file'))
+
+        wildcard_mime = '%s/*' % mime.split('/')[0]
+
+        if mime not in self.mimetypes and wildcard_mime not in self.mimetypes:
+            msg = _('%(file)s is not a valid file. Allowed file types are : %(types)s') % {
+                'file': fp.name,
+                'types': ', '.join(self.mimetypes),
+            }
+            raise ValidationError(msg)
+
+    def __eq__(self, other):
+        return self.mimetypes == other.mimetypes
+
+
+validate_images = FileMimetypeValidator(['image/*',])
+validate_videos = FileMimetypeValidator(['video/*',])
+validate_audios = FileMimetypeValidator(['audio/*',])
+
+validate_documents = FileMimetypeValidator([
+    #Main document mimetypes for CSV, DOC, XLS, PPT, ODT, ODS, ODP, PDF
+    'application/msword', 
+    'application/pdf',
+    'application/vnd.ms-excel', 
+    'application/vnd.ms-powerpoint',
+    'application/vnd.oasis.opendocument.text', 
+    'application/vnd.oasis.opendocument.spreadsheet',
+    'application/vnd.oasis.opendocument.presentation',
+    'text/csv',])
+
+validate_html5_images = FileMimetypeValidator([
+    #Main supported mime types for web image content : SVG, JPEG, PNG, GIF
+    'image/svg+xml', #http://caniuse.com/#feat=svg
+    'image/jpeg', 'image/png', 'image/gif'])
+
+validate_html5_videos = FileMimetypeValidator([
+    #Main supported mime types for web video content : OGV, MP4, WEBM
+    'video/ogg', #http://caniuse.com/#search=ogg
+    'video/mp4', #http://caniuse.com/#search=mp4
+    'video/webm',#http://caniuse.com/#search=webm
+    ])
+
+validate_html5_audios = FileMimetypeValidator([
+    #Main supported mime types for web audio content : AAC, OGG, MP4, MP3, WAV, WEBM
+    'audio/aac', 'audio/ogg', 'audio/mp4', 'audio/mpeg', 'audio/wav', 'audio/webm',])

--- a/filer/views.py
+++ b/filer/views.py
@@ -1,23 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import json
 from django import forms
 from django.contrib.admin import widgets
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
-from django.db.models import get_model
-from django.forms.models import modelform_factory
-from django.http import HttpResponseRedirect, HttpResponse, Http404
+from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils.translation import ugettext_lazy as _
-from django.views.decorators.csrf import csrf_exempt
 
 from .models import Folder, File, Image, Clipboard, tools, FolderRoot
 from . import settings as filer_settings
-from .utils.files import handle_upload, UploadException
-from .utils.loader import load_object
-from .validators import FileMimetypeValidator
 
 
 class NewFolderForm(forms.ModelForm):
@@ -206,74 +199,3 @@ def clone_files_from_clipboard_to_folder(request):
                                 request.POST.get('redirect_to', ''),
                                 popup_param(request),
                                 selectfolder_param(request)))
-
-
-@csrf_exempt
-@login_required
-def ajax_upload(request):
-    mimetype = "application/json"
-    response_params = {
-        'content_type': mimetype,
-    }
-    try:
-        if not request.is_ajax():
-            raise UploadException("Request is not an AJAX request.")
-        mimetypes = []
-        folder_key = None
-        related_field = request.GET.get('related_field', None)
-        if related_field:
-            related_field = related_field.split('.')
-            if len(related_field) != 3:
-                raise UploadException("Related field is not valid.")
-            try:
-                model = get_model(related_field[0], related_field[1])
-                field = model._meta.get_field_by_name(related_field[2])[0]
-            except:
-                raise UploadException("Related field is not valid.")
-            for validator in field.validators:
-                if isinstance(validator, FileMimetypeValidator):
-                    mimetypes += validator.mimetypes
-        upload, filename, is_raw = handle_upload(request, mimetypes)
-        filename = filename.split('\\')[-1].split('/')[-1]
-        # find the file type
-        for filer_class in filer_settings.FILER_FILE_MODELS:
-            FileSubClass = load_object(filer_class)
-            # TODO: What to do if there are more than one that qualify?
-            if FileSubClass.matches_file_type(filename, upload, request):
-                FileForm = modelform_factory(
-                    model=FileSubClass,
-                    fields=('original_filename', 'owner', 'file')
-                )
-                break
-        uploadform = FileForm({'original_filename': filename,
-                               'owner': request.user.pk},
-                              {'file': upload})
-        if uploadform.is_valid():
-            file_obj = uploadform.save(commit=False)
-            # Enforce the FILER_IS_PUBLIC_DEFAULT
-            file_obj.is_public = filer_settings.FILER_IS_PUBLIC_DEFAULT
-            folder_key = request.GET.get('folder_key', folder_key)
-            if folder_key:
-                from .utils.folders import get_default_folder_getter
-                folder = get_default_folder_getter().get(folder_key, request)
-                if folder:
-                    if not folder.has_add_children_permission(request):
-                        # the user does not have the permission to add elements into the folder
-                        raise PermissionDenied
-                    file_obj.folder = folder
-            file_obj.save()
-            json_response = {
-                'thumbnail': file_obj.icons['48'],
-                'label': str(file_obj),
-                'pk': file_obj.pk,
-            }
-            return HttpResponse(json.dumps(json_response), **response_params)
-        else:
-            form_errors = '; '.join(['%s: %s' % (
-                fieldname,
-                ', '.join(errors)) for fieldname, errors in list(uploadform.errors.items())
-            ])
-            raise UploadException("AJAX request not valid: form invalid '%s'" % (form_errors,))
-    except UploadException as e:
-        return HttpResponse(json.dumps({'error': str(e)}),
-                            **response_params)

--- a/filer/views.py
+++ b/filer/views.py
@@ -1,16 +1,23 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import json
 from django import forms
 from django.contrib.admin import widgets
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponseRedirect, Http404
+from django.db.models import get_model
+from django.forms.models import modelform_factory
+from django.http import HttpResponseRedirect, HttpResponse, Http404
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils.translation import ugettext_lazy as _
+from django.views.decorators.csrf import csrf_exempt
 
 from .models import Folder, File, Image, Clipboard, tools, FolderRoot
 from . import settings as filer_settings
+from .utils.files import handle_upload, UploadException
+from .utils.loader import load_object
+from .validators import FileMimetypeValidator
 
 
 class NewFolderForm(forms.ModelForm):
@@ -199,3 +206,74 @@ def clone_files_from_clipboard_to_folder(request):
                                 request.POST.get('redirect_to', ''),
                                 popup_param(request),
                                 selectfolder_param(request)))
+
+
+@csrf_exempt
+@login_required
+def ajax_upload(request):
+    mimetype = "application/json"
+    response_params = {
+        'content_type': mimetype,
+    }
+    try:
+        if not request.is_ajax():
+            raise UploadException("Request is not an AJAX request.")
+        mimetypes = []
+        folder_key = None
+        related_field = request.GET.get('related_field', None)
+        if related_field:
+            related_field = related_field.split('.')
+            if len(related_field) != 3:
+                raise UploadException("Related field is not valid.")
+            try:
+                model = get_model(related_field[0], related_field[1])
+                field = model._meta.get_field_by_name(related_field[2])[0]
+            except:
+                raise UploadException("Related field is not valid.")
+            for validator in field.validators:
+                if isinstance(validator, FileMimetypeValidator):
+                    mimetypes += validator.mimetypes
+        upload, filename, is_raw = handle_upload(request, mimetypes)
+        filename = filename.split('\\')[-1].split('/')[-1]
+        # find the file type
+        for filer_class in filer_settings.FILER_FILE_MODELS:
+            FileSubClass = load_object(filer_class)
+            # TODO: What to do if there are more than one that qualify?
+            if FileSubClass.matches_file_type(filename, upload, request):
+                FileForm = modelform_factory(
+                    model=FileSubClass,
+                    fields=('original_filename', 'owner', 'file')
+                )
+                break
+        uploadform = FileForm({'original_filename': filename,
+                               'owner': request.user.pk},
+                              {'file': upload})
+        if uploadform.is_valid():
+            file_obj = uploadform.save(commit=False)
+            # Enforce the FILER_IS_PUBLIC_DEFAULT
+            file_obj.is_public = filer_settings.FILER_IS_PUBLIC_DEFAULT
+            folder_key = request.GET.get('folder_key', folder_key)
+            if folder_key:
+                from .utils.folders import get_default_folder_getter
+                folder = get_default_folder_getter().get(folder_key, request)
+                if folder:
+                    if not folder.has_add_children_permission(request):
+                        # the user does not have the permission to add elements into the folder
+                        raise PermissionDenied
+                    file_obj.folder = folder
+            file_obj.save()
+            json_response = {
+                'thumbnail': file_obj.icons['48'],
+                'label': str(file_obj),
+                'pk': file_obj.pk,
+            }
+            return HttpResponse(json.dumps(json_response), **response_params)
+        else:
+            form_errors = '; '.join(['%s: %s' % (
+                fieldname,
+                ', '.join(errors)) for fieldname, errors in list(uploadform.errors.items())
+            ])
+            raise UploadException("AJAX request not valid: form invalid '%s'" % (form_errors,))
+    except UploadException as e:
+        return HttpResponse(json.dumps({'error': str(e)}),
+                            **response_params)

--- a/test_settings.py
+++ b/test_settings.py
@@ -18,6 +18,7 @@ HELPER_SETTINGS = {
         'mptt',
         'filer',
         'filer.test_utils.test_app',
+        'filer.test_utils.thirdparty_app',
     ],
     'LANGUAGE_CODE': 'en',
     'LANGUAGES': (
@@ -58,7 +59,7 @@ HELPER_SETTINGS = {
     'TEMPLATE_DIRS': (os.path.join(BASE_DIR, 'django-filer', 'filer',
                                    'test_utils', 'templates'),),
     'FILER_CANONICAL_URL': 'test-path/',
-
+    'FILER_DEFAULT_FOLDER_GETTER': 'filer.test_utils.thirdparty_app.handlers.CustomFolderGetter',
 }
 if os.environ.get('CUSTOM_IMAGE', False):
     HELPER_SETTINGS['FILER_IMAGE_MODEL'] = os.environ.get('CUSTOM_IMAGE', False)

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
 [testenv:docs]
 changedir = docs
 deps =
+    lxml
     sphinx
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
@@ -41,6 +42,7 @@ commands =
 setenv =
     custom_image: CUSTOM_IMAGE=filer.test_utils.custom_image.models.Image
 deps =
+    lxml
     thumbs1x: easy-thumbnails>=1.4,<2.0
     thumbs2x: easy-thumbnails>=2.0,<2.4
     django15: -rtest_requirements/django-1.5.txt

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands = flake8
 
 [flake8]
 ignore = E251,E128,E501
-exclude = build/*,docs/*,filer/migrations/*,filer/south_migrations/*,filer/migrations_django/*,filer/settings.py,filer/tests/*,filer/test_utils/custom_image/*,filer/test_utils/test_app/south_migrations/*
+exclude = build/*,docs/*,filer/migrations/*,filer/south_migrations/*,filer/migrations_django/*,filer/settings.py,filer/tests/*,filer/test_utils/custom_image/*,filer/test_utils/test_app/south_migrations/*,filer/test_utils/thirdparty_app/south_migrations/*,filer/test_utils/thirdparty_app/migrations/*
 max-line-length = 80
 
 [testenv:frontend]


### PR DESCRIPTION
With this pull request, when a dev define an Image's foeignKey, he can configure :
- available mimetypes via the FileMimetypeValidator : takes a list of allowed mime subtypes (e.g: `image/jpeg`) and/or mimetypes (e.g: `image/*`)
- choose which upload method is available when the widget will be displayed (by default : old method is activated (file lookup). the second one is "direct upload" : a simple "browse" button : when we choose a file, ajax upload is performed. Both methods can be enabled together : choose a file from the website ou on the PC)
- default folder where the file will be uploaded : when direct upload is enabled and the user upload a file, the new file will be linked to the configured folder. It's done by sending a folder "key" which must be a class method of a `DefaultFolderGetter child`. This method takes the request and must return a folder.

Tests for "dynamic" folder destination and mimetype detections  have been added.
If you think this pull request is usefull and mergeable, I'll add:
- documentation 
- tests for third party models with File/Image foreign keys.
- direct_upload will also send a "related_field" data of this format : "model_name.field_name" (e.g: `'News.illustration'`). `direct_upload`'s view will be able to retrieve validators associated to this field and reject files during the ajax upload and not only when the object (the news) is saved.

Simple usage exemple:

``` python
#my_news_app/models.py
# [...] imports and other required things...

class News(NewsboxBase):
    illustration = FilerImageField(
        verbose_name=_('illustration'), 
        default_direct_upload_enabled=True, 
        #add a "browse" button with ajax upload
        default_file_lookup_enabled=False, 
        #remove the file lookup link. The user will only have a browse button to add new files
        direct_upload_folder_key='USER_OWN_FOLDER', 
        #file will be uploaded in a specifc folder owned by the authenticated user
        validators=[FileMimetypeValidator(['image/png', 'image/jpeg'])], 
        #only jpeg and PNG are allowed
        null=True, blank=True)
```

``` python
#my_news_app/utils.py
from filer.utils.folders import DefaultFolderGetter

class MyCustomFolderGetter(DefaultFolderGetter)
    @classmethod
    def USER_OWN_FOLDER(cls, request):
        if not request.user.is_authenticated():
            return None
        folder = Folder.objects.filter(owner=request.user, parent_id=USERS_FOLDER_PK)[0:1]
        if not folder:
            folder = Folder()
            folder.name = request.user.username
            folder.parent_id = USERS_FOLDER_PK
            folder.owner = request.user
            folder.save()
        else:
            folder = folder[0]
        return folder
```

``` python
#project/settings.py

FILER_DEFAULT_FOLDER_GETTER = 'my_news_app.utils.MyCustomFolderGetter'
```
