### PR TITLE
unlimit dropzone filesize

### DIFF
--- a/filer/static/filer/js/addons/dropzone.init.js
+++ b/filer/static/filer/js/addons/dropzone.init.js
@@ -24,7 +24,6 @@ django.jQuery(function ($) {
     var hiddenClass = 'hidden';
     var mobileClass = 'filer-dropzone-mobile';
     var objectAttachedClass = 'js-object-attached';
-    // var dataMaxFileSize = 'max-file-size';
     var minWidth = 500;
     var checkMinWidth = function (element) {
         element.toggleClass(mobileClass, element.width() < minWidth);
@@ -65,8 +64,8 @@ django.jQuery(function ($) {
             url: dropzoneUrl,
             paramName: 'file',
             maxFiles: 1,
-            // for now disabled as we don't have the correct file size limit
-            // maxFilesize: dropzone.data(dataMaxFileSize) || 20, // MB
+            // filer and django do not limit file size, let's use some ridiculously large value
+            maxFilesize: 4000000, // MB
             previewTemplate: $(dropzoneTemplateSelector).html(),
             clickable: false,
             addRemoveLinks: false,

--- a/filer/static/filer/js/addons/table-dropzone.js
+++ b/filer/static/filer/js/addons/table-dropzone.js
@@ -74,8 +74,8 @@
                     url: dropzoneUrl,
                     paramName: 'file',
                     maxFiles: 100,
-                    // for now disabled as we don't have the correct file size limit
-                    // maxFilesize: dropzone.data(dataMaxFileSize) || 20, // MB
+                    // filer and django do not limit file size, let's use some ridiculously large value
+                    maxFilesize: 4000000, // MB
                     previewTemplate: '<div></div>',
                     clickable: false,
                     addRemoveLinks: false,

--- a/filer/templates/admin/filer/folder/directory_table.html
+++ b/filer/templates/admin/filer/folder/directory_table.html
@@ -1,7 +1,7 @@
 {% load i18n l10n admin_list filer_tags filer_admin_tags staticfiles %}
 <div class="drag-hover-border"></div>
 <section class="navigator{% if is_popup %} navigator-popup{% endif %}">
-    <table class="js-filer-dropzone js-filer-dropzone-base navigator-table" id="result_list" data-url="{% if folder.id %}{% url 'admin:filer-ajax_upload' folder_id=folder.id %}{% else %}{% url 'admin:filer-ajax_upload' %}{% endif %}" data-folder-name="{% if folder.is_root %}{% trans 'Unsorted Uploads' %}{% else %}{{ folder.name }}{% endif %}" data-max-uploader-connections="{{ uploader_connections }}" data-max-file-size="20">
+    <table class="js-filer-dropzone js-filer-dropzone-base navigator-table" id="result_list" data-url="{% if folder.id %}{% url 'admin:filer-ajax_upload' folder_id=folder.id %}{% else %}{% url 'admin:filer-ajax_upload' %}{% endif %}" data-folder-name="{% if folder.is_root %}{% trans 'Unsorted Uploads' %}{% else %}{{ folder.name }}{% endif %}" data-max-uploader-connections="{{ uploader_connections }}">
         <thead>
             <tr>
                 <th class="column-checkbox">
@@ -39,7 +39,7 @@
             {% for item in paginated_items.object_list %}
                 {% if item.file_type == "Folder" %}
                     {% with item as subfolder %}
-                        <tr class="js-filer-dropzone js-filer-dropzone-folder" data-url="{% url 'admin:filer-ajax_upload' folder_id=subfolder.id %}" data-folder-name="{{ subfolder.name }}" data-max-uploader-connections="{{ uploader_connections }}" data-max-file-size="20">
+                        <tr class="js-filer-dropzone js-filer-dropzone-folder" data-url="{% url 'admin:filer-ajax_upload' folder_id=subfolder.id %}" data-folder-name="{{ subfolder.name }}" data-max-uploader-connections="{{ uploader_connections }}">
                             <td class="column-checkbox">
                                 {% if filer_admin_context.pick_folder and item.file_type == 'Folder' %}
                                     <a class="insertlink insertlinkButton"
@@ -154,7 +154,7 @@
         </tbody>
     </table>
 
-    <div class="filer-dropzone-info-message js-filer-dropzone js-filer-dropzone-info-message hidden" data-url="{% if folder.id %}{% url 'admin:filer-ajax_upload' folder_id=folder.id %}{% else %}{% url 'admin:filer-ajax_upload' %}{% endif %}" data-folder-name="{% if folder.is_root %}{% trans 'Unsorted Uploads' %}{% else %}{{ folder.name }}{% endif %}" data-max-uploader-connections="{{ uploader_connections }}" data-max-file-size="20">
+    <div class="filer-dropzone-info-message js-filer-dropzone js-filer-dropzone-info-message hidden" data-url="{% if folder.id %}{% url 'admin:filer-ajax_upload' folder_id=folder.id %}{% else %}{% url 'admin:filer-ajax_upload' %}{% endif %}" data-folder-name="{% if folder.is_root %}{% trans 'Unsorted Uploads' %}{% else %}{{ folder.name }}{% endif %}" data-max-uploader-connections="{{ uploader_connections }}">
         <div class="icon"><span class="fa fa-cloud-upload"></span></div>
 
         <div class="filer-dropzone-upload-welcome js-filer-dropzone-upload-welcome">

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -11,7 +11,7 @@
         </span>
     </div>
 
-    <div class="js-filer-dropzone filer-dropzone{% if object %} js-object-attached{% endif %}" data-url="{% url 'admin:filer-ajax_upload' %}" data-max-file-size="20">
+    <div class="js-filer-dropzone filer-dropzone{% if object %} js-object-attached{% endif %}" data-url="{% url 'admin:filer-ajax_upload' %}">
         <div class="z-index-fix"></div>
         <div class="dz-default dz-message js-filer-dropzone-message{% if object %} hidden{% endif %}">
             <span class="icon fa fa-arrow-down"></span><span>{% trans "or drop your file here" %}</span>


### PR DESCRIPTION
Since filer is using older dropzone, it defaults to max file size of 256 MB. This is way too low and there's no reasons to limit it from django side.