### PR TITLE
Removed never used and non-working FolderManager.

### DIFF
--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -17,11 +17,6 @@ from .. import settings as filer_settings
 from . import mixins
 
 
-class FolderManager(models.Manager):
-    def with_bad_metadata(self):
-        return self.get_query_set().filter(has_all_mandatory_data=False)
-
-
 class FolderPermissionManager(models.Manager):
     """
     Theses methods are called by introspection from "has_generic_permisison" on
@@ -129,8 +124,6 @@ class Folder(MPTTModel, mixins.IconsMixin):
 
     created_at = models.DateTimeField(_('created at'), auto_now_add=True)
     modified_at = models.DateTimeField(_('modified at'), auto_now=True)
-
-    objects = FolderManager()
 
     @property
     def file_count(self):


### PR DESCRIPTION
`FolderManager` seems unused and non-working since its introduction in cec6054df3fb96af5d0060f4bdae219f92ff1940. Also it shadows `mptt.TreeManager`.