### PR TITLE
Correcting get_exif_for_file with custom storage

### DIFF
--- a/filer/utils/pil_exif.py
+++ b/filer/utils/pil_exif.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from django.core.files.storage import default_storage as storage
+from django.core.files.storage import default_storage
 
 from ..utils.compatibility import PILExifTags, PILImage
 
@@ -19,6 +19,7 @@ def get_exif(im):
 
 
 def get_exif_for_file(file_obj):
+    storage = getattr(file_obj, 'storage', default_storage)
     im = PILImage.open(storage.open(file_obj.name), 'r')
     return get_exif(im)
 

--- a/filer/utils/pil_exif.py
+++ b/filer/utils/pil_exif.py
@@ -19,7 +19,9 @@ def get_exif(im):
 
 
 def get_exif_for_file(file_obj):
-    storage = getattr(file_obj, 'storage', default_storage)
+    storage = getattr(file_obj, 'storage', None)
+    if storage is None:
+        storage = default_storage
     im = PILImage.open(storage.open(file_obj.name), 'r')
     return get_exif(im)
 


### PR DESCRIPTION
Correct bug with the followed settings:

```
PUBLIC_URL = '/'
MEDIA_URL = os.path.join(PUBLIC_URL, 'media/')
THUMBNAIL_MEDIA_URL = os.path.join(MEDIA_URL, 'thumbnails/')

PUBLIC_ROOT = os.path.join(BASE_DIR, 'static_files')
MEDIA_ROOT = os.path.join(PUBLIC_ROOT, 'media')
THUMBNAIL_MEDIA_ROOT = os.path.join(MEDIA_ROOT, 'thumbnails')

FILER_STORAGES = {
    'public': {
        'main': {
            'ENGINE': 'filer.storage.PublicFileSystemStorage',
            'OPTIONS': {
                'location': os.path.join(MEDIA_ROOT, 'filer'),
                'base_url': os.path.join(MEDIA_URL, 'filer'),
            },
            'UPLOAD_TO_PREFIX': '',
        },
        'thumbnails': {
            'ENGINE': 'filer.storage.PublicFileSystemStorage',
            'OPTIONS': {
                'location': os.path.join(THUMBNAIL_MEDIA_ROOT, 'filer'),
                'base_url': os.path.join(THUMBNAIL_MEDIA_URL, 'filer'),
            },
            'THUMBNAIL_OPTIONS': {
                'base_dir': '',
            },
        },
    }
}
```