### PR TITLE
[WIP] Customizable folder/file querysets and virtual folders via overridable managers

### DIFF
--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -28,6 +28,16 @@ class FileAdmin(PrimitivePermissionAwareModelAdmin):
 
     form = FileAdminChangeFrom
 
+    def get_queryset(self, request):
+        # instead of default manager (which might be overriden)
+        # _file_manager is used which is always guaranteed to have
+        # filter_for_user functionality
+        qs = self.model._file_manager.filter_for_user(request.user)
+        ordering = self.get_ordering(request)
+        if ordering:
+            qs = qs.order_by(*ordering)
+        return qs
+
     @classmethod
     def build_fieldsets(cls, extra_main_fields=(), extra_advanced_fields=(),
                         extra_fieldsets=()):

--- a/filer/admin/permissions.py
+++ b/filer/admin/permissions.py
@@ -6,6 +6,24 @@ from django.core.urlresolvers import reverse
 
 
 class PrimitivePermissionAwareModelAdmin(admin.ModelAdmin):
+    # FIXME: this class should be refactored to use only built-in Django permission handling
+    # but with obj being passed. Then we can implement auth backend for filer which would do permission
+    # checking for filer models only. It would just use existing obj.has_edit_permission, etc.
+    # So if someone wants to override permission checking they could use whatever they want from existing
+    # Django permission handling apps supporting obj-level permissions (like django-rules or
+    # django-guardian). When permission handling is overriden, FILER_ENABLE_PERMISSIONS setting would be
+    # False. When it is True (using integrated filer permissions), we could have some system check to see
+    # if filer auth backend is in AUTH_BACKENDS setting.
+    # However, there are a few tricky parts to this:
+    # * filer's read permission could be changed to 'view' permission which is available since Django 2.1.
+    #   It would still have to be enabled through File and Folder Meta.default_permissions.
+    # * 'add' permission in filer uses related folder (so obj should be a folder while permission being
+    #   checked is either 'add_file' or 'add_folder'. This kind of behavior (obj for add where obj model
+    #   does not necessarily match permission model) is already used for inline admin permission checking
+    #   in Django 2.1 therefore it's not something non-standard.
+    # * When checking 'change' or 'delete' permissions for files, permissions should always match File content
+    #   type instead of specific File subclasses so 'change_image' would never be used for example. This is
+    #   also a common practice when checking permissions for polymorphic models.
     def has_add_permission(self, request):
         # we don't have a "add" permission... but all adding is handled
         # by special methods that go around these permissions anyway
@@ -30,6 +48,7 @@ class PrimitivePermissionAwareModelAdmin(admin.ModelAdmin):
         Needed to retrieve the changelist url as Folder/File can be extended
         and admin url may change
         """
+        # FIXME: remove. This is not used.
         # Code from django ModelAdmin to determine changelist on the fly
         opts = obj._meta
         return reverse('admin:%s_%s_changelist' %

--- a/filer/admin/views.py
+++ b/filer/admin/views.py
@@ -11,7 +11,7 @@ from django.shortcuts import render
 from django.utils.translation import ugettext_lazy as _
 
 from .. import settings as filer_settings
-from ..models import Clipboard, Folder, FolderRoot, tools
+from ..models import Clipboard, Folder, tools
 from .tools import AdminContext, admin_url_params_encoded, popup_status
 
 
@@ -52,7 +52,7 @@ def make_folder(request, folder_id=None):
         new_folder_form = NewFolderForm(request.POST)
         if new_folder_form.is_valid():
             new_folder = new_folder_form.save(commit=False)
-            if (folder or FolderRoot()).contains_folder(new_folder.name):
+            if (folder or Folder.objects.root_folder).contains_folder(new_folder.name):
                 new_folder_form._errors['name'] = new_folder_form.error_class(
                     [_('Folder with this name already exists.')])
             else:

--- a/filer/managers.py
+++ b/filer/managers.py
@@ -86,7 +86,7 @@ class FolderPermissionManager(models.Manager):
 
                 ids = Folder.objects.all().values_list('id', flat=True)
             elif perm.type == self.model.CHILDREN:
-                ids = perm.folder.get_descendants().values_list('id', flat=True)
+                ids = perm.folder.get_descendants(include_self=True).values_list('id', flat=True)
             else:
                 ids = [perm.folder.id]
 

--- a/filer/managers.py
+++ b/filer/managers.py
@@ -31,6 +31,9 @@ class FolderManager(TreeManager):
     def filter_for_user(self, user):
         return self.get_queryset().filter_for_user(user)
 
+    def get_default_folder(self, file_model=None):
+        return self.root_folder.get_default_folder(file_model)
+
     @property
     def root_folder(self):
         from .models.virtualitems import FolderRoot

--- a/filer/managers.py
+++ b/filer/managers.py
@@ -1,0 +1,107 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.db import models
+from django.db.models import Q
+from mptt.managers import TreeManager
+
+from . import settings as filer_settings
+
+try:
+    from polymorphic.managers import PolymorphicManager
+except ImportError:
+    # django-polymorphic < 0.8
+    from polymorphic import PolymorphicManager
+
+
+class FolderManager(TreeManager):
+    def virtual_folders(self):
+        return []
+
+    def root_folder(self):
+        return []
+
+    def children_for(self, folder):
+        pass
+
+
+class FolderPermissionManager(models.Manager):
+    """
+    Theses methods are called by introspection from "has_generic_permisison" on
+    the folder model.
+    """
+    def get_read_id_list(self, user):
+        """
+        Give a list of a Folders where the user has read rights or the string
+        "All" if the user has all rights.
+        """
+        return self.__get_id_list(user, "can_read")
+
+    def get_edit_id_list(self, user):
+        return self.__get_id_list(user, "can_edit")
+
+    def get_add_children_id_list(self, user):
+        return self.__get_id_list(user, "can_add_children")
+
+    def __get_id_list(self, user, attr):
+        from .models.foldermodels import Folder
+
+        if user.is_superuser or not filer_settings.FILER_ENABLE_PERMISSIONS:
+            return 'All'
+        allow_list = set()
+        deny_list = set()
+        group_ids = user.groups.all().values_list('id', flat=True)
+        q = Q(user=user) | Q(group__in=group_ids) | Q(everybody=True)
+        perms = self.filter(q).order_by('folder__tree_id', 'folder__level',
+                                        'folder__lft')
+        for perm in perms:
+            p = getattr(perm, attr)
+
+            if p is None:
+                # Not allow nor deny, we continue with the next permission
+                continue
+
+            if not perm.folder:
+                assert perm.type == self.model.ALL
+
+                all_folder_ids = Folder.objects.all().values_list('id', flat=True)
+                if p == self.model.ALLOW:
+                    allow_list.update(all_folder_ids)
+                else:
+                    deny_list.update(all_folder_ids)
+
+                continue
+
+            folder_id = perm.folder.id
+
+            if p == self.model.ALLOW:
+                allow_list.add(folder_id)
+            else:
+                deny_list.add(folder_id)
+
+            if perm.type == self.model.CHILDREN:
+                # FIXME: use Folder.objects.children_for(perm.folder) instead
+                folder_children_ids = perm.folder.get_descendants().values_list('id', flat=True)
+                if p == self.model.ALLOW:
+                    allow_list.update(folder_children_ids)
+                else:
+                    deny_list.update(folder_children_ids)
+
+        # Deny has precedence over allow
+        return allow_list - deny_list
+
+
+class FileManager(PolymorphicManager):
+    def in_folder(self, folder):
+        pass
+
+    def find_all_duplicates(self):
+        r = {}
+        for file_obj in self.all():
+            if file_obj.sha1:
+                q = self.filter(sha1=file_obj.sha1)
+                if len(q) > 1:
+                    r[file_obj.sha1] = q
+        return r
+
+    def find_duplicates(self, file_obj):
+        return [i for i in self.exclude(pk=file_obj.pk).filter(sha1=file_obj.sha1)]

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -21,24 +21,9 @@ from .foldermodels import Folder
 
 try:
     from polymorphic.models import PolymorphicModel
-    from polymorphic.managers import PolymorphicManager
 except ImportError:
     # django-polymorphic < 0.8
-    from polymorphic import PolymorphicModel, PolymorphicManager
-
-
-class FileManager(PolymorphicManager):
-    def find_all_duplicates(self):
-        r = {}
-        for file_obj in self.all():
-            if file_obj.sha1:
-                q = self.filter(sha1=file_obj.sha1)
-                if len(q) > 1:
-                    r[file_obj.sha1] = q
-        return r
-
-    def find_duplicates(self, file_obj):
-        return [i for i in self.exclude(pk=file_obj.pk).filter(sha1=file_obj.sha1)]
+    from polymorphic import PolymorphicModel
 
 
 def is_public_default():
@@ -82,7 +67,7 @@ class File(PolymorphicModel, mixins.IconsMixin):
                     'file. File will be publicly accessible '
                     'to anyone.'))
 
-    objects = FileManager()
+    objects = load_object(filer_settings.FILER_FILE_MANAGER)()
 
     @classmethod
     def matches_file_type(cls, iname, ifile, request):

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -17,6 +17,7 @@ from . import mixins
 from .. import settings as filer_settings
 from ..fields.multistorage_file import MultiStorageFileField
 from ..utils.compatibility import python_2_unicode_compatible
+from ..utils.loader import load_object
 from .foldermodels import Folder
 
 try:

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -68,7 +68,10 @@ class File(PolymorphicModel, mixins.IconsMixin):
                     'file. File will be publicly accessible '
                     'to anyone.'))
 
-    objects = load_object(filer_settings.FILER_FILE_MANAGER)()
+    # Here additional '_file_manager' manager accessor is added so that if child classes
+    # override default manager, original file manager is still accessible.
+    _file_manager = load_object(filer_settings.FILER_FILE_MANAGER)()
+    objects = _file_manager
 
     @classmethod
     def matches_file_type(cls, iname, ifile, request):

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -318,8 +318,7 @@ class File(PolymorphicModel, mixins.IconsMixin):
         Folder object
         """
         if not self.folder:
-            from .virtualitems import UnsortedImages
-            return UnsortedImages()
+            return Folder.objects.get_default_folder(self.__class__)
         else:
             return self.folder
 

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -65,9 +65,15 @@ class Folder(MPTTModel, mixins.IconsMixin):
     def item_count(self):
         return self.file_count + self.children_count
 
+    def get_children_for_user(self, user):
+        return self.children.filter_for_user(user)
+
     @property
     def files(self):
         return self.all_files.all()
+
+    def get_files_for_user(self, user):
+        return self.files.filter_for_user(user)
 
     @property
     def logical_path(self):

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -2,89 +2,24 @@
 
 from __future__ import absolute_import, unicode_literals
 
-import mptt
 from django.conf import settings
 from django.contrib.auth import models as auth_models
 from django.core import urlresolvers
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Q
 from django.utils.http import urlquote
 from django.utils.translation import ugettext_lazy as _
+from mptt.models import MPTTModel
 
 from . import mixins
 from .. import settings as filer_settings
 from ..utils.compatibility import python_2_unicode_compatible
-
-
-class FolderManager(models.Manager):
-    def with_bad_metadata(self):
-        return self.get_query_set().filter(has_all_mandatory_data=False)
-
-
-class FolderPermissionManager(models.Manager):
-    """
-    Theses methods are called by introspection from "has_generic_permisison" on
-    the folder model.
-    """
-    def get_read_id_list(self, user):
-        """
-        Give a list of a Folders where the user has read rights or the string
-        "All" if the user has all rights.
-        """
-        return self.__get_id_list(user, "can_read")
-
-    def get_edit_id_list(self, user):
-        return self.__get_id_list(user, "can_edit")
-
-    def get_add_children_id_list(self, user):
-        return self.__get_id_list(user, "can_add_children")
-
-    def __get_id_list(self, user, attr):
-        if user.is_superuser or not filer_settings.FILER_ENABLE_PERMISSIONS:
-            return 'All'
-        allow_list = set()
-        deny_list = set()
-        group_ids = user.groups.all().values_list('id', flat=True)
-        q = Q(user=user) | Q(group__in=group_ids) | Q(everybody=True)
-        perms = self.filter(q).order_by('folder__tree_id', 'folder__level',
-                                        'folder__lft')
-        for perm in perms:
-            p = getattr(perm, attr)
-
-            if p is None:
-                # Not allow nor deny, we continue with the next permission
-                continue
-
-            if not perm.folder:
-                assert perm.type == FolderPermission.ALL
-
-                if p == FolderPermission.ALLOW:
-                    allow_list.update(Folder.objects.all().values_list('id', flat=True))
-                else:
-                    deny_list.update(Folder.objects.all().values_list('id', flat=True))
-
-                continue
-
-            folder_id = perm.folder.id
-
-            if p == FolderPermission.ALLOW:
-                allow_list.add(folder_id)
-            else:
-                deny_list.add(folder_id)
-
-            if perm.type == FolderPermission.CHILDREN:
-                if p == FolderPermission.ALLOW:
-                    allow_list.update(perm.folder.get_descendants().values_list('id', flat=True))
-                else:
-                    deny_list.update(perm.folder.get_descendants().values_list('id', flat=True))
-
-        # Deny has precedence over allow
-        return allow_list - deny_list
+from ..utils.loader import load_object
+from .managers import FolderPermissionManager
 
 
 @python_2_unicode_compatible
-class Folder(models.Model, mixins.IconsMixin):
+class Folder(MPTTModel, mixins.IconsMixin):
     """
     Represents a Folder that things (files) can be put into. Folders are *NOT*
     mirrored in the Filesystem and can have any unicode chars as their name.
@@ -112,7 +47,7 @@ class Folder(models.Model, mixins.IconsMixin):
     created_at = models.DateTimeField(_('created at'), auto_now_add=True)
     modified_at = models.DateTimeField(_('modified at'), auto_now=True)
 
-    objects = FolderManager()
+    objects = load_object(filer_settings.FILER_FOLDER_MANAGER)()
 
     @property
     def file_count(self):
@@ -234,12 +169,6 @@ class Folder(models.Model, mixins.IconsMixin):
         app_label = 'filer'
         verbose_name = _("Folder")
         verbose_name_plural = _("Folders")
-
-# MPTT registration
-try:
-    mptt.register(Folder)
-except mptt.AlreadyRegistered:
-    pass
 
 
 @python_2_unicode_compatible

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -15,7 +15,7 @@ from . import mixins
 from .. import settings as filer_settings
 from ..utils.compatibility import python_2_unicode_compatible
 from ..utils.loader import load_object
-from .managers import FolderPermissionManager
+from ..managers import FolderPermissionManager
 
 
 @python_2_unicode_compatible

--- a/filer/models/virtualitems.py
+++ b/filer/models/virtualitems.py
@@ -2,40 +2,54 @@
 
 from __future__ import absolute_import
 
+import warnings
+from collections import OrderedDict
+
 from django.core import urlresolvers
+from django.db.models import Q
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from . import mixins
 from .. import settings as filer_settings
 from .filemodels import File
-from .foldermodels import Folder
+from .foldermodels import Folder, FolderPermission
 
 
 class DummyFolder(mixins.IconsMixin):
     file_type = 'DummyFolder'
     name = "Dummy Folder"
+    slug = None
     is_root = True
     is_smart_folder = True
     can_have_subfolders = False
     parent = None
     _icon = "plainfolder"
+    virtual_folder_classes = []
 
-    @property
+    def __eq__(self, other):
+        return self.__class__ == other.__class__
+
+    @cached_property
     def virtual_folders(self):
-        return {}
-
-    def get_virtual_folder(self, slug):
-        return
+        return OrderedDict((f.slug, f()) for f in self.virtual_folder_classes)
 
     @property
     def children(self):
+        warnings.warn("'children' property on virtual folders should not be used. "
+                      "Use 'get_children_for_user' instead.",
+                      DeprecationWarning, stacklevel=2)
+        return Folder.objects.none()
+
+    def get_children_for_user(self, user):
         return Folder.objects.none()
 
     @property
     def files(self):
         return File.objects.none()
-    parent_url = None
+
+    def get_files_for_user(self, user):
+        return self.files.filter_for_user(user)
 
     @property
     def image_files(self):
@@ -49,9 +63,16 @@ class DummyFolder(mixins.IconsMixin):
         """
         return []
 
+    def get_admin_directory_listing_url_path(self):
+        if self.slug is None:
+            return
+        return urlresolvers.reverse(
+            'admin:filer-directory_listing-%s' % self.slug)
+
 
 class UnsortedImages(DummyFolder):
     name = _("Unsorted Uploads")
+    slug = 'unfiled_images'
     is_root = True
     is_unsorted_uploads = True
     _icon = "unfiled_folder"
@@ -60,13 +81,10 @@ class UnsortedImages(DummyFolder):
         return File.objects.filter(folder__isnull=True)
     files = property(_files)
 
-    def get_admin_directory_listing_url_path(self):
-        return urlresolvers.reverse(
-            'admin:filer-directory_listing-unfiled_images')
-
 
 class ImagesWithMissingData(DummyFolder):
     name = _("files with missing metadata")
+    slug = 'images_with_missing_data'
     is_root = True
     _icon = "incomplete_metadata_folder"
 
@@ -74,42 +92,36 @@ class ImagesWithMissingData(DummyFolder):
     def files(self):
         return File.objects.filter(has_all_mandatory_data=False)
 
-    def get_admin_directory_listing_url_path(self):
-        return urlresolvers.reverse(
-            'admin:filer-directory_listing-images_with_missing_data')
-
 
 class FolderRoot(DummyFolder):
     name = _('root')
+    slug = 'root'
     is_root = True
     is_smart_folder = False
     can_have_subfolders = True
-
-    @cached_property
-    def virtual_folders(self):
-        return {
-            'unfiled_images': UnsortedImages(),
-        }
-
-    def get_virtual_folder(self, slug):
-        return self.virtual_folders.get(slug)
+    virtual_folder_classes = [UnsortedImages]
 
     @property
     def children(self):
-        # FIXME: this doesn't make much sense because in FolderAdmin.directory_listing parent__isnull=False
-        # is excluded, so it's the same as if this 'if' did not exist...
+        warnings.warn("'children' property on virtual folders should not be used. "
+                      "Use 'get_children_for_user' instead.",
+                      DeprecationWarning, stacklevel=2)
         if filer_settings.FILER_ENABLE_PERMISSIONS:
             return Folder.objects.all()
         return Folder.objects.filter(parent__isnull=True)
-    parent_url = None
+
+    def get_children_for_user(self, user):
+        perms = FolderPermission.objects.get_read_id_list(user)
+        if perms != 'All':
+            qs = Folder.objects.filter_for_user(user)
+            # get folders which are in root or user has only indirect access to (permission for nested folder
+            # but not it's parent)
+            return qs.exclude(Q(parent__isnull=False) & (Q(parent__id__in=perms) | Q(owner=user)))
+        return Folder.objects.filter(parent__isnull=True)
 
     def contains_folder(self, folder_name):
-        # FIXME: when filer_settings.FILER_ENABLE_PERMISSIONS is True, this doesn't work properly :)
         try:
-            self.children.get(name=folder_name)
+            Folder.objects.filter(parent__isnull=True).get(name=folder_name)
             return True
         except Folder.DoesNotExist:
             return False
-
-    def get_admin_directory_listing_url_path(self):
-        return urlresolvers.reverse('admin:filer-directory_listing-root')

--- a/filer/models/virtualitems.py
+++ b/filer/models/virtualitems.py
@@ -119,6 +119,15 @@ class FolderRoot(DummyFolder):
             return qs.exclude(Q(parent__isnull=False) & (Q(parent__id__in=perms) | Q(parent__owner=user)))
         return Folder.objects.filter(parent__isnull=True)
 
+    def get_default_folder(self, file_model=None):
+        """
+        Returns default virtual folder for File (sub)model.
+        Default implementation always returns UnsortedImages virtual folder.
+        This is used mostly for redirecting to relevant directory listing after various actions
+        in admin.
+        """
+        return self.virtual_folders['unfiled_images']
+
     def contains_folder(self, folder_name):
         try:
             Folder.objects.filter(parent__isnull=True).get(name=folder_name)

--- a/filer/models/virtualitems.py
+++ b/filer/models/virtualitems.py
@@ -116,7 +116,7 @@ class FolderRoot(DummyFolder):
             qs = Folder.objects.filter_for_user(user)
             # get folders which are in root or user has only indirect access to (permission for nested folder
             # but not it's parent)
-            return qs.exclude(Q(parent__isnull=False) & (Q(parent__id__in=perms) | Q(owner=user)))
+            return qs.exclude(Q(parent__isnull=False) & (Q(parent__id__in=perms) | Q(parent__owner=user)))
         return Folder.objects.filter(parent__isnull=True)
 
     def contains_folder(self, folder_name):

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 if not hasattr(settings, 'FILER_IMAGE_MODEL'):
     setattr(settings, 'FILER_IMAGE_MODEL', 'filer.Image')
 FILER_IMAGE_MODEL = settings.FILER_IMAGE_MODEL
+FILER_FOLDER_MANAGER = getattr(settings, 'FILER_FOLDER_MANAGER', 'filer.managers.FolderManager')
+FILER_FILE_MANAGER = getattr(settings, 'FILER_FILE_MANAGER', 'filer.managers.FileManager')
 
 FILER_DEBUG = getattr(settings, 'FILER_DEBUG', False)  # When True makes
 FILER_SUBJECT_LOCATION_IMAGE_DEBUG = getattr(settings, 'FILER_SUBJECT_LOCATION_IMAGE_DEBUG', False)


### PR DESCRIPTION
So the idea of this PR is to make it possible to override virtual folders and queryset filtering for non-admin users. This is all achieved by making settings for ```File``` and ```Folder``` manager paths so that they are imported dynamically and then overriding functionality through managers and querysets. Works like a charm! The next thing to do is making permission handling customizable as well so that folder/file permissions can be dealt with outside of filer (with setting FILER_ENABLE_PERMISSIONS=False).
I tried very hard to keep compatibility with existing implementation. Coincidentally, some bugs were fixed:
* possibility to use "limit search to folder" inside virtual folders;
* folders shown in root folder for non-admin user;
* destination folders for copy/move actions for non-admin users;
* files shown in FileAdmin listing for non-admin users (although there are no links to that page, but it's working).

I would really like to get some comments on this! My plan is to continue with permission handling overhaul (as detailed in admin.permissions) and some other related developments until this is finished. Also, this supersedes PRs #1068 and #1069.