### PR TITLE
Fix directory listing template conflict with djangocms-admin-style

### DIFF
--- a/filer/templates/admin/filer/folder/directory_listing.html
+++ b/filer/templates/admin/filer/folder/directory_listing.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block coltype %}{% endblock %}
-{% block bodyclass %}change-list filebrowser{% endblock %}
+{% block bodyclass %}{{ block.super }} change-list filebrowser{% endblock %}
 
 
 {% block extrastyle %}


### PR DESCRIPTION
This PR fixes the directory listing template by adding the missing `{{ block.super }}` directive in
the `bodyclass` block of `directory_listing.html` template which overwrites the body class added
by [djangocms-admin-style](https://github.com/django-cms/djangocms-admin-style) app.

**Changed**
- Added `{{ block.super }}` in the `bodyclass` block of `directory_listing.html` template.

**Fixed**
- Issue #1234 
