### PR TITLE
Improve PermissionAdmin performance

### DIFF
--- a/filer/admin/permissionadmin.py
+++ b/filer/admin/permissionadmin.py
@@ -13,7 +13,7 @@ class PermissionAdmin(admin.ModelAdmin):
         )}),
     )
     raw_id_fields = ('user', 'group',)
-    list_filter = ['user']
+    list_filter = ['group']
     list_display = ['__str__', 'folder', 'user']
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):

--- a/filer/admin/permissionadmin.py
+++ b/filer/admin/permissionadmin.py
@@ -17,6 +17,10 @@ class PermissionAdmin(admin.ModelAdmin):
     list_display = ['__str__', 'folder', 'user']
     search_fields = ["user__username", "group__name", "folder__name"]
 
+    def get_queryset(self, request):
+        qs = super(PermissionAdmin, self).get_queryset(request)
+        return qs.prefetch_related("group", "folder")
+
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         db = kwargs.get('using')
         if db_field.name == 'folder':

--- a/filer/admin/permissionadmin.py
+++ b/filer/admin/permissionadmin.py
@@ -15,6 +15,7 @@ class PermissionAdmin(admin.ModelAdmin):
     raw_id_fields = ('user', 'group',)
     list_filter = ['group']
     list_display = ['__str__', 'folder', 'user']
+    search_fields = ["user__username", "group__name", "folder__name"]
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         db = kwargs.get('using')


### PR DESCRIPTION
Filer's permission admin page scales really bad for a larger user base (>280k entries) and a lot of permissions - so here are the patches I use to cope with it.