### PR TITLE
fix dropzone error callback for admin fields

### DIFF
--- a/filer/static/filer/js/addons/dropzone.init.js
+++ b/filer/static/filer/js/addons/dropzone.init.js
@@ -130,8 +130,11 @@ djQuery(function ($) {
                     event.preventDefault();
                 });
             },
-            error: function (file, response) {
-                showError(file.name + ': ' + response.error);
+            error: function (file, msg, response) {
+                if(response && response.error){
+                    msg += ' ; ' + response.error;
+                }
+                showError(file.name + ': ' + msg);
                 this.removeAllFiles(true);
             },
             reset: function () {


### PR DESCRIPTION
Fx dropzone error callback for admin fields which has not good parameters (`file, response` instead of `file, error, response`)

Dropzone documentation say:  
> An error occured. Receives the errorMessage as second parameter and if the error was due to the XMLHttpRequest the xhr object as third.  
https://www.dropzonejs.com/#event-error