### PR TITLE
Fix 404 error for thumbnail.

### DIFF
--- a/filer/server/views.py
+++ b/filer/server/views.py
@@ -51,7 +51,7 @@ def serve_protected_thumbnail(request, path):
             raise Http404('File not found')
     try:
         thumbnail = ThumbnailFile(name=path, storage=file_obj.file.thumbnail_storage)
-        thumbnail_temp_file = File(file=thumbnail, mime_type=file_obj.mime_type)
-        return thumbnail_server.serve(request, thumbnail_temp_file, save_as=False)
+        thumbnail.mime_type = file_obj.mime_type
+        return thumbnail_server.serve(request, thumbnail, save_as=False)
     except Exception:
         raise Http404('File not found')


### PR DESCRIPTION
fix 404 error for thumbnail.

## Description

`File(file=thumbnail, mime_type=file_obj.mime_type)` will modify thumbnail.path(smedia/filer_private_thumbnails/ to media/). 

My Django version is 3.2.10