### PR TITLE
fix: readme is missing the updated requirement on Python 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ for all the details on how to install, configure and use django-filer.
 .. |coverage| image:: https://codecov.io/gh/django-cms/django-filer/branch/master/graph/badge.svg
     :target: https://codecov.io/gh/django-cms/django-filer
 
-.. |python| image:: https://img.shields.io/badge/python-3.5+-blue.svg
+.. |python| image:: https://img.shields.io/badge/python-3.6+-blue.svg
     :target: https://pypi.org/project/django-filer/
 .. |django| image:: https://img.shields.io/badge/django-2.2,%203.0,%203.1-blue.svg
     :target: https://www.djangoproject.com/


### PR DESCRIPTION
## Description

Document the fact that Python 3.6 is required as already described in the changelog.

## Related resources



## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
