### PR TITLE
fix: Define a ``default_auto_field`` on the app config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+Unreleased
+==========
+
+* Fix: Define a ``default_auto_field`` as part of the app config.
+
 2.2 (2022-04-20)
 ================
 

--- a/filer/apps.py
+++ b/filer/apps.py
@@ -3,5 +3,6 @@ from django.utils.translation import gettext_lazy as _
 
 
 class FilerConfig(AppConfig):
+    default_auto_field = 'django.db.models.AutoField'
     name = 'filer'
     verbose_name = _("Filer")


### PR DESCRIPTION
## Description

This defines a ``default_auto_field`` on the app config so django won't try to create migrations for the app if someone moves their project to big auto field.

## Related resources

* #1293

## Checklist

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
