### PR TITLE
fix: file widget styling on mobile devices

### DIFF
--- a/filer/private/sass/components/_drag-and-drop.scss
+++ b/filer/private/sass/components/_drag-and-drop.scss
@@ -287,11 +287,13 @@ form .form-row {
                     vertical-align: middle;
                     margin: 0;
                 }
+                @media screen and (max-width: 1024px) {
+                    margin-left: 15px !important;
+                }
             }
         }
         &.filer-dropzone-mobile {
             .filerFile {
-                top: 40px;
                 text-align: center;
             }
             .dz-message {
@@ -302,22 +304,22 @@ form .form-row {
                 margin-top: 75px;
             }
             &.js-object-attached .filerFile {
-                top: 32px;
-                text-align: left;
+                text-align: center;
                 &.js-file-selector {
                     @media screen and (max-width: $screen-tablet-filer) {
                         .description_text {
                             text-overflow: ellipsis;
-                            width: calc(100% - 150px);
+                            width: calc(100% - 200px);
                             overflow: hidden;
                             height: 20px;
                         }
                     }
-                    span:not(.choose-file):not(.edit-file), .dz-name {
-                        width: calc(100% - 145px);
+                    >span:not(.choose-file):not(.edit-file), .dz-name {
+                        width: calc(100% - 200px);
                     }
                 }
             }
+
         }
         &.filer-dropzone-folder .filerFile {
             top: 32px !important;
@@ -325,6 +327,11 @@ form .form-row {
                 float: left;
             }
         }
+
+        @media (max-width: 767px) {
+            flex-grow: 1;
+        }
+
     }
 }
 


### PR DESCRIPTION
## Description

Fix file widget on mobile devices.

Before/After:
![2022-07-28_140425](https://user-images.githubusercontent.com/1167556/181502533-c7196cb8-6977-4eeb-ba91-2e04735b8e42.jpg)



## Related resources

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
