### PR TITLE
Install django-filer with SVG support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ from filer import __version__
 
 
 REQUIREMENTS = [
-    'django>=2.2,<4.1',
+    'django>=2.2,<5',
     'django-mptt',
     'django-polymorphic',
-    'easy-thumbnails>=2.8.0',
+    'easy-thumbnails[svg]',
     'Unidecode>=0.04,<1.2',
 ]
 


### PR DESCRIPTION
## Description

Since version 2.8.2 of [easy-thumbnails](https://github.com/SmileyChris/easy-thumbnails) one must explicitly install the extra dependencies for SVG. This is done by `pip install easy-thumbnails[svg]`.

This pull request fixes this installation problem.

## Related resources

https://github.com/SmileyChris/easy-thumbnails/pull/597

## Checklist

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
