### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -6,7 +6,7 @@ Run the documentation locally
 -----------------------------
 
 Install the Enchant library
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You will need to install the
 `enchant <https://www.abisource.com/projects/enchant/>`__ library that

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -5,7 +5,7 @@ Django Filer Documentation
 Run the documentation locally
 -----------------------------
 
-Install the Enchant libary
+Install the Enchant library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You will need to install the

--- a/docs/secure_downloads.rst
+++ b/docs/secure_downloads.rst
@@ -48,7 +48,7 @@ live in ``filer.server.backends`` and it is easy to create new ones.
 The default is ``filer.server.backends.default.DefaultServer``. It is suitable
 for development and serves the file directly from django.
 
-More suitiable for production are server backends that delegate the actual file
+More suitable for production are server backends that delegate the actual file
 serving to an upstream webserver.
 
 ``NginxXAccelRedirectServer``

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -689,7 +689,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         Action which deletes the selected files and/or folders.
 
         This action first displays a confirmation page whichs shows all the
-        deleteable files and/or folders, or, if the user has no permission on
+        deletable files and/or folders, or, if the user has no permission on
         one of the related childs (foreignkeys), a "permission denied" message.
 
         Next, it deletes all selected files and/or folders and redirects back to

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -19,7 +19,7 @@ from . import mixins
 
 class FolderPermissionManager(models.Manager):
     """
-    Theses methods are called by introspection from "has_generic_permisison" on
+    Theses methods are called by introspection from "has_generic_permission" on
     the folder model.
     """
     def get_read_id_list(self, user):

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -19,7 +19,7 @@ from . import mixins
 
 class FolderPermissionManager(models.Manager):
     """
-    Theses methods are called by introspection from "has_generic_permission" on
+    These methods are called by introspection from "has_generic_permission" on
     the folder model.
     """
     def get_read_id_list(self, user):

--- a/filer/templatetags/filer_admin_tags.py
+++ b/filer/templatetags/filer_admin_tags.py
@@ -109,7 +109,7 @@ def file_icon_context(file, detail, width, height):
 @register.inclusion_tag('admin/filer/templatetags/file_icon.html')
 def file_icon(file, detail=False, size=None):
     """
-    This templatetag returns a redered `<img src="..." srcset="..." width="..." height="..." class="..." />
+    This templatetag returns a rendered `<img src="..." srcset="..." width="..." height="..." class="..." />
     to be used for rendering thumbnails of files in the directory listing or in the corresponding detail
     views for that image.
     """

--- a/filer/thumbnail_processors.py
+++ b/filer/thumbnail_processors.py
@@ -119,7 +119,7 @@ def scale_and_crop_with_subject_location(im, size, subject_location=False,
     if ex or ey:
         crop_box = ((int(tex), int(tey), int(tfx), int(tfy)))
         if FILER_SUBJECT_LOCATION_IMAGE_DEBUG:
-            # draw elipse on focal point for Debugging
+            # draw ellipse on focal point for Debugging
             draw = ImageDraw.Draw(im)
             esize = 10
             draw.ellipse(((subj_x - esize, subj_y - esize),

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -48,7 +48,7 @@ def create_image(mode='RGB', size=(800, 600)):
 
 class SettingsOverride:
     """
-    Overrides Django settings within a context and resets them to their inital
+    Overrides Django settings within a context and resets them to their initial
     values on exit.
 
     Example:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -569,7 +569,7 @@ class FilerBulkOperationsTests(BulkOperationsMixin, TestCase):
           |
           |--bar
 
-        and try to move the owter bar in foo. This has to fail since it would result
+        and try to move the outer bar in foo. This has to fail since it would result
         in two folders with the same name and parent.
         """
         root = Folder.objects.create(name='root', owner=self.superuser)


### PR DESCRIPTION
There are small typos in:
- docs/README.rst
- docs/secure_downloads.rst
- filer/admin/folderadmin.py
- filer/models/foldermodels.py
- filer/templatetags/filer_admin_tags.py
- filer/thumbnail_processors.py
- tests/helpers.py
- tests/test_admin.py

Fixes:
- Should read `suitable` rather than `suitiable`.
- Should read `rendered` rather than `redered`.
- Should read `outer` rather than `owter`.
- Should read `permission` rather than `permisison`.
- Should read `library` rather than `libary`.
- Should read `initial` rather than `inital`.
- Should read `ellipse` rather than `elipse`.
- Should read `deletable` rather than `deleteable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md