### PR TITLE
Fix thumbnail generation for SVG images when used as a Divio addon

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 CHANGELOG
 =========
 
+
+Unreleased
+==========
+
+* Fix thumbnail generation for SVG images when used as a Divio addon.
+
+
 2.2.3 (2022-08-08)
 ==================
 * Fix CSS styles (Modified SCSS had to be recompiled).

--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -29,15 +29,6 @@ class Form(forms.BaseForm):
         # easy-thumbnails
         settings['THUMBNAIL_QUALITY'] = env('THUMBNAIL_QUALITY', 90)
         settings['THUMBNAIL_PRESERVE_EXTENSIONS'] = ['png', 'gif']
-        settings['THUMBNAIL_PROCESSORS'] = (
-            'easy_thumbnails.processors.colorspace',
-            'easy_thumbnails.processors.autocrop',
-            'filer.thumbnail_processors.scale_and_crop_with_subject_location',
-            'easy_thumbnails.processors.filters',
-        )
-        settings['THUMBNAIL_SOURCE_GENERATORS'] = (
-            'easy_thumbnails.source_generators.pil_image',
-        )
         settings['THUMBNAIL_CACHE_DIMENSIONS'] = True
 
         # easy_thumbnails uses django's default storage backend (local file


### PR DESCRIPTION
Remove hardcoded settings from alrdryn_config.py and use the defaults
provided by easy-thumbnails.

Fixes #1310 