### PR TITLE
feat: Add django 4.1 and Python 3.11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         requirements-file: [
           django-2.2.txt,
           django-3.0.txt,
           django-3.1.txt,
           django-3.2.txt,
-          django-4.0.txt
+          django-4.0.txt,
+          django-4.1.txt
         ]
         exclude:
           - python-version: 3.7
             requirements-file: django-4.0.txt
+          - python-version: 3.7
+            requirements-file: django-4.1.txt
           - python-version: 3.9
             requirements-file: django-2.2.txt
           - python-version: 3.10
@@ -26,6 +29,12 @@ jobs:
           - python-version: 3.10
             requirements-file: django-3.0.txt
           - python-version: 3.10
+            requirements-file: django-3.1.txt
+          - python-version: 3.11
+            requirements-file: django-2.2.txt
+          - python-version: 3.11
+            requirements-file: django-3.0.txt
+          - python-version: 3.11
             requirements-file: django-3.1.txt
         os: [
           ubuntu-20.04,

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+unreleased
+==========
+* Add Django 4.1 support
+* Add python 3.11 tests
+
 2.2.3 (2022-08-08)
 ==================
 * Fix CSS styles (Modified SCSS had to be recompiled).

--- a/README.rst
+++ b/README.rst
@@ -59,5 +59,5 @@ for all the details on how to install, configure and use django-filer.
 
 .. |python| image:: https://img.shields.io/badge/python-3.7+-blue.svg
     :target: https://pypi.org/project/django-filer/
-.. |django| image:: https://img.shields.io/badge/django-2.2,%203.2,%204.0-blue.svg
+.. |django| image:: https://img.shields.io/badge/django-2.2,%203.2,%204.1-blue.svg
     :target: https://www.djangoproject.com/

--- a/filer/server/backends/default.py
+++ b/filer/server/backends/default.py
@@ -25,7 +25,7 @@ class DefaultServer(ServerBase):
         statobj = os.stat(fullpath)
         response_params = {'content_type': filer_file.mime_type}
         if not was_modified_since(request.META.get('HTTP_IF_MODIFIED_SINCE'),
-                                  statobj[stat.ST_MTIME], statobj[stat.ST_SIZE]):
+                                  statobj[stat.ST_MTIME]):
             return HttpResponseNotModified(**response_params)
         response = HttpResponse(open(fullpath, 'rb').read(), **response_params)
         response["Last-Modified"] = http_date(statobj[stat.ST_MTIME])

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ REQUIREMENTS = [
     'django>=2.2,<5',
     'django-mptt',
     'django-polymorphic',
-    'easy-thumbnails[svg]',
+    'easy-thumbnails',
     'Unidecode>=0.04,<1.2',
 ]
 
@@ -24,12 +24,14 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Framework :: Django',
     'Framework :: Django :: 2.2',
     'Framework :: Django :: 3.0',
     'Framework :: Django :: 3.1',
     'Framework :: Django :: 3.2',
     'Framework :: Django :: 4.0',
+    'Framework :: Django :: 4.1',
     'Framework :: Django CMS',
     'Framework :: Django CMS :: 3.6',
     'Framework :: Django CMS :: 3.7',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ REQUIREMENTS = [
     'django>=2.2,<5',
     'django-mptt',
     'django-polymorphic',
-    'easy-thumbnails',
+    'easy-thumbnails[svg]',
     'Unidecode>=0.04,<1.2',
 ]
 

--- a/tests/requirements/django-4.1.txt
+++ b/tests/requirements/django-4.1.txt
@@ -1,0 +1,5 @@
+-r base.txt
+
+django>=4.1,<4.2
+django_polymorphic>=3.1
+https://github.com/jrief/django-app-helper/archive/refs/heads/develop.zip


### PR DESCRIPTION
## Description

This PR adds tests for Django 4.1 and Python 3.11 


## Related resources

* The size argument to `was_modified_since()` has been removed (https://docs.djangoproject.com/en/4.1/releases/4.1/#miscellaneous)

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
