### PR TITLE
Fix popup window name to element id transform

### DIFF
--- a/filer/static/filer/js/addons/popup_handling.js
+++ b/filer/static/filer/js/addons/popup_handling.js
@@ -12,7 +12,7 @@ if (django.jQuery) {
     function windowname_to_id(text) {
         text = text.replace(/__dot__/g, '.');
         text = text.replace(/__dash__/g, '-');
-        return text;
+        return text.split('__')[0];
     }
 
     window.dismissPopupAndReload = function (win) {


### PR DESCRIPTION
## Description

Django 4.1 adds a [popup index to the admin popup window name](https://github.com/django/django/commit/492ed60f236d770eb9a6d56d85ff2550bb1ecfff) that needs to be stripped when getting back to the element id.

This should be backwards compatible to previous element ids unless they use double underscores (`__`) in them.

## Checklist

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
