### PR TITLE
Feature/custom validation for upload

### DIFF
--- a/docs/extending_filer.rst
+++ b/docs/extending_filer.rst
@@ -307,3 +307,34 @@ Set ``FILER_IMAGE_MODEL`` to the path of your custom model:
 .. code-block:: python
 
     FILER_IMAGE_MODEL = 'myapp.CustomImage'
+
+
+Customize Upload Validation
+...........................
+
+Set a custom validation function before storing a File into the Filer.
+Sometimes you might want to restrict the upload according to some defined
+criterias. For example: "All the image files must be lower than 10 MB" 
+For this you can set a custom upload validation function in your settings: 
+
+Set ``FILER_CUSTOM_UPLOAD_VALIDATION`` to the path of your custom function:
+
+.. code-block:: python
+
+    FILER_CUSTOM_UPLOAD_VALIDATION = 'myapp.filer.custom_upload_validation'
+
+
+The signature of the function should look like this:
+
+.. code-block:: python
+
+    def custom_validation_func(request, upload, filename, mime_type):
+        from pathlib import Path
+
+        file_extension = Path(filename).suffix
+
+        image_extensions = ['.jpg', 'png', '.svg', '.webp']
+
+        if file_extension in image_extensions and upload.size > 10485760:
+            return 'Image files should be lower than 10 MB'
+

--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -91,6 +91,12 @@ def ajax_upload(request, folder_id=None):
     # Get clipboad
     # clipboard = Clipboard.objects.get_or_create(user=request.user)[0]
 
+    validate_upload_func = getattr(filer_settings, 'FILER_CUSTOM_UPLOAD_VALIDATION_FUNC', None)
+    if validate_upload_func is not None:
+        error_message = validate_upload_func(request, upload, filename, mime_type)
+        if error_message is not None:
+            return JsonResponse({'error': error_message})
+
     # find the file type
     for filer_class in filer_settings.FILER_FILE_MODELS:
         FileSubClass = load_model(filer_class)

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -274,3 +274,6 @@ FILER_FOLDER_ADMIN_LIST_TYPE_SWITCHER_SETTINGS = {
         'template': 'admin/filer/folder/directory_thumbnail_list.html',
     },
 }
+
+FILER_CUSTOM_UPLOAD_VALIDATION = getattr(settings, 'FILER_CUSTOM_UPLOAD_VALIDATION', None)
+FILER_CUSTOM_UPLOAD_VALIDATION_FUNC = load_object(FILER_CUSTOM_UPLOAD_VALIDATION) if FILER_CUSTOM_UPLOAD_VALIDATION is not None else None 


### PR DESCRIPTION
Add possiblity to add a custom upload validation function in a project.

## Description

Sometimes you might want to restrict the file upload according to some defined
criteria. For example: "All image files must be lower than 10 MB" 

## Checklist

* [X] I have opened this pull request against ``master``
* [X] I have added or modified the tests when changing logic
* [X] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

I don't know if there is already a better way 😄, so I am happy for every feedback
