### PR TITLE
Removing Unidecode dependency to avoid GPL clashes

### DIFF
--- a/filer/utils/files.py
+++ b/filer/utils/files.py
@@ -6,8 +6,6 @@ from django.template.defaultfilters import slugify as slugify_django
 from django.utils.encoding import force_str
 from django.utils.text import get_valid_filename as get_valid_filename_django
 
-from unidecode import unidecode
-
 
 class UploadException(Exception):
     pass
@@ -120,7 +118,7 @@ def handle_request_files_upload(request):
 
 
 def slugify(string):
-    return slugify_django(unidecode(force_str(string)))
+    return slugify_django(force_str(string))
 
 
 def get_valid_filename(s):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ REQUIREMENTS = [
     'django-mptt',
     'django-polymorphic',
     'easy-thumbnails[svg]',
-    'Unidecode>=0.04,<1.2',
 ]
 
 


### PR DESCRIPTION
## Description

Remove Unidecode dependency to avoid GPL clashes.

## Related resources

* https://github.com/django-cms/django-filer/issues/1266

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
