### PR TITLE
fix: respect upload and directory listing permissions

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -234,6 +234,8 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
 
     # custom views
     def directory_listing(self, request, folder_id=None, viewtype=None):
+        if not request.user.has_perm("filer.can_use_directory_listing"):
+            raise PermissionDenied()
         clipboard = tools.get_user_clipboard(request.user)
         if viewtype == 'images_with_missing_data':
             folder = ImagesWithMissingData()

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -300,13 +300,13 @@ class File(PolymorphicModel, mixins.IconsMixin):
         return self.label.lower() < other.label.lower()
 
     def has_edit_permission(self, request):
-        return self.has_generic_permission(request, 'edit')
+        return request.user.has_perm("filer.change_file") and self.has_generic_permission(request, 'edit')
 
     def has_read_permission(self, request):
         return self.has_generic_permission(request, 'read')
 
     def has_add_children_permission(self, request):
-        return self.has_generic_permission(request, 'add_children')
+        return request.user.has_perm("filer.add_file") and self.has_generic_permission(request, 'add_children')
 
     def has_generic_permission(self, request, permission_type):
         """

--- a/filer/models/foldermodels.py
+++ b/filer/models/foldermodels.py
@@ -200,13 +200,13 @@ class Folder(models.Model, mixins.IconsMixin):
         return urlquote(self.pretty_logical_path)
 
     def has_edit_permission(self, request):
-        return self.has_generic_permission(request, 'edit')
+        return request.user.has_perm("filer.change_folder") and self.has_generic_permission(request, 'edit')
 
     def has_read_permission(self, request):
         return self.has_generic_permission(request, 'read')
 
     def has_add_children_permission(self, request):
-        return self.has_generic_permission(request, 'add_children')
+        return request.user.has_perm("filer.change_folder") and self.has_generic_permission(request, 'add_children')
 
     def has_generic_permission(self, request, permission_type):
         """

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -259,7 +259,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
                 'Filedata': file_obj,
                 'jsessionid': self.client.session.session_key
             }
-            self.client.post(url, post_data, **extra_headers)  # noqa
+            self.client.post(url, post_data, **extra_headers)
 
         self.assertEqual(Image.objects.count(), 1)
         self.assertEqual(Image.objects.all()[0].original_filename,
@@ -282,7 +282,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
                     'Filedata': file_obj,
                     'jsessionid': self.client.session.session_key
                 }
-                self.client.post(url, post_data, **extra_headers)  # noqa
+                self.client.post(url, post_data, **extra_headers)
 
             self.assertEqual(Video.objects.count(), 1)
             self.assertEqual(Video.objects.all()[0].original_filename, self.video_name)
@@ -304,7 +304,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
                     'Filedata': file_obj,
                     'jsessionid': self.client.session.session_key
                 }
-                self.client.post(url, post_data, **extra_headers)  # noqa
+                self.client.post(url, post_data, **extra_headers)
 
             self.assertEqual(ExtImage.objects.count(), 1)
             self.assertEqual(ExtImage.objects.all()[0].original_filename, self.image_name)
@@ -335,7 +335,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
                 'Filedata': file_obj,
                 'jsessionid': self.client.session.session_key
             }
-            self.client.post(url, post_data, **extra_headers)  # noqa
+            self.client.post(url, post_data, **extra_headers)
             self.assertEqual(Image.objects.count(), 0)
             self.assertEqual(File.objects.count(), 1)
             stored_file = File.objects.first()
@@ -371,7 +371,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
                 'admin:filer-ajax_upload',
                 kwargs={'folder_id': folder.pk}
             ) + '?filename=renamed.pdf'
-            self.client.post(  # noqa
+            self.client.post(
                 url,
                 data=file_obj.read(),
                 content_type='application/pdf',
@@ -390,7 +390,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
             url = reverse(
                 'admin:filer-ajax_upload'
             ) + '?filename=%s' % self.image_name
-            self.client.post(  # noqa
+            self.client.post(
                 url,
                 data=file_obj.read(),
                 content_type='image/jpeg',

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.admin import helpers
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.forms.models import model_to_dict as model_to_dict_django
 from django.test import TestCase
 from django.urls import reverse
@@ -429,6 +430,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
             username='joe_new', password='x', email='joe@mata.com')
         staff_user.is_staff = True
         staff_user.save()
+        staff_user.user_permissions.add(*Permission.objects.filter(codename="add_file"))
         self.client.login(username='joe_new', password='x')
         self.assertEqual(Image.objects.count(), 0)
         folder = Folder.objects.create(name='foo')
@@ -463,6 +465,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
             username='joe_new', password='x', email='joe@mata.com')
         staff_user.is_staff = True
         staff_user.save()
+        staff_user.user_permissions.add(*Permission.objects.filter(codename="add_file"))
         self.client.login(username='joe_new', password='x')
         self.assertEqual(Image.objects.count(), 0)
         folder = Folder.objects.create(name='foo')
@@ -895,6 +898,8 @@ class FolderListingTest(TestCase):
             username='joe', password='x', email='joe@mata.com')
         self.staff_user.is_staff = True
         self.staff_user.save()
+        perms = Permission.objects.filter(codename__in=["view_folder", "add_file", "add_folder", "can_use_directory_listing"])
+        self.staff_user.user_permissions.add(*perms)
         self.parent = Folder.objects.create(name='bar', parent=None, owner=superuser)
 
         self.foo_folder = Folder.objects.create(name='foo', parent=self.parent, owner=self.staff_user)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -251,14 +251,15 @@ class FilerClipboardAdminUrlsTests(TestCase):
     def test_filer_upload_file(self, extra_headers={}):
         self.assertEqual(Image.objects.count(), 0)
         folder = Folder.objects.create(name='foo')
-        file_obj = django.core.files.File(open(self.filename, 'rb'))
-        url = reverse('admin:filer-ajax_upload', kwargs={'folder_id': folder.pk})
-        post_data = {
-            'Filename': self.image_name,
-            'Filedata': file_obj,
-            'jsessionid': self.client.session.session_key
-        }
-        response = self.client.post(url, post_data, **extra_headers)  # noqa
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
+            url = reverse('admin:filer-ajax_upload', kwargs={'folder_id': folder.pk})
+            post_data = {
+                'Filename': self.image_name,
+                'Filedata': file_obj,
+                'jsessionid': self.client.session.session_key
+            }
+            response = self.client.post(url, post_data, **extra_headers)  # noqa
         self.assertEqual(Image.objects.count(), 1)
         self.assertEqual(Image.objects.all()[0].original_filename,
                          self.image_name)
@@ -272,14 +273,15 @@ class FilerClipboardAdminUrlsTests(TestCase):
         )):
             self.assertEqual(Video.objects.count(), 0)
             folder = Folder.objects.create(name='foo')
-            file_obj = django.core.files.File(open(self.video_filename, 'rb'))
-            url = reverse('admin:filer-ajax_upload', kwargs={'folder_id': folder.pk})
-            post_data = {
-                'Filename': self.video_name,
-                'Filedata': file_obj,
-                'jsessionid': self.client.session.session_key
-            }
-            response = self.client.post(url, post_data, **extra_headers)  # noqa
+            with open(self.video_filename, 'rb') as fh:
+                file_obj = django.core.files.File(fh)
+                url = reverse('admin:filer-ajax_upload', kwargs={'folder_id': folder.pk})
+                post_data = {
+                    'Filename': self.video_name,
+                    'Filedata': file_obj,
+                    'jsessionid': self.client.session.session_key
+                }
+                response = self.client.post(url, post_data, **extra_headers)  # noqa
             self.assertEqual(Video.objects.count(), 1)
             self.assertEqual(Video.objects.all()[0].original_filename, self.video_name)
 
@@ -292,62 +294,66 @@ class FilerClipboardAdminUrlsTests(TestCase):
         )):
             self.assertEqual(ExtImage.objects.count(), 0)
             folder = Folder.objects.create(name='foo')
-            file_obj = django.core.files.File(open(self.filename, 'rb'))
-            url = reverse('admin:filer-ajax_upload', kwargs={'folder_id': folder.pk})
+            with open(self.filename, 'rb') as fh:
+                file_obj = django.core.files.File(fh)
+                url = reverse('admin:filer-ajax_upload', kwargs={'folder_id': folder.pk})
+                post_data = {
+                    'Filename': self.image_name,
+                    'Filedata': file_obj,
+                    'jsessionid': self.client.session.session_key
+                }
+                response = self.client.post(url, post_data, **extra_headers)  # noqa
+            self.assertEqual(ExtImage.objects.count(), 1)
+            self.assertEqual(ExtImage.objects.all()[0].original_filename, self.image_name)
+
+    def test_filer_upload_file_no_folder(self, extra_headers={}):
+        self.assertEqual(Image.objects.count(), 0)
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
+            url = reverse('admin:filer-ajax_upload')
             post_data = {
                 'Filename': self.image_name,
                 'Filedata': file_obj,
                 'jsessionid': self.client.session.session_key
             }
             response = self.client.post(url, post_data, **extra_headers)  # noqa
-            self.assertEqual(ExtImage.objects.count(), 1)
-            self.assertEqual(ExtImage.objects.all()[0].original_filename, self.image_name)
-
-    def test_filer_upload_file_no_folder(self, extra_headers={}):
-        self.assertEqual(Image.objects.count(), 0)
-        file_obj = django.core.files.File(open(self.filename, 'rb'))
-        url = reverse('admin:filer-ajax_upload')
-        post_data = {
-            'Filename': self.image_name,
-            'Filedata': file_obj,
-            'jsessionid': self.client.session.session_key
-        }
-        response = self.client.post(url, post_data, **extra_headers)  # noqa
-        self.assertEqual(Image.objects.count(), 1)
-        stored_image = Image.objects.first()
-        self.assertEqual(stored_image.original_filename, self.image_name)
-        self.assertEqual(stored_image.mime_type, 'image/jpeg')
+            self.assertEqual(Image.objects.count(), 1)
+            stored_image = Image.objects.first()
+            self.assertEqual(stored_image.original_filename, self.image_name)
+            self.assertEqual(stored_image.mime_type, 'image/jpeg')
 
     def test_filer_upload_binary_data(self, extra_headers={}):
         self.assertEqual(File.objects.count(), 0)
-        file_obj = django.core.files.File(open(self.binary_filename, 'rb'))
-        url = reverse('admin:filer-ajax_upload')
-        post_data = {
-            'Filename': self.binary_name,
-            'Filedata': file_obj,
-            'jsessionid': self.client.session.session_key
-        }
-        response = self.client.post(url, post_data, **extra_headers)  # noqa
-        self.assertEqual(Image.objects.count(), 0)
-        self.assertEqual(File.objects.count(), 1)
-        stored_file = File.objects.first()
-        self.assertEqual(stored_file.original_filename, self.binary_name)
-        self.assertEqual(stored_file.mime_type, 'application/octet-stream')
+        with open(self.binary_filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
+            url = reverse('admin:filer-ajax_upload')
+            post_data = {
+                'Filename': self.binary_name,
+                'Filedata': file_obj,
+                'jsessionid': self.client.session.session_key
+            }
+            response = self.client.post(url, post_data, **extra_headers)  # noqa
+            self.assertEqual(Image.objects.count(), 0)
+            self.assertEqual(File.objects.count(), 1)
+            stored_file = File.objects.first()
+            self.assertEqual(stored_file.original_filename, self.binary_name)
+            self.assertEqual(stored_file.mime_type, 'application/octet-stream')
 
     def test_filer_ajax_upload_file(self):
         self.assertEqual(Image.objects.count(), 0)
         folder = Folder.objects.create(name='foo')
-        file_obj = django.core.files.File(open(self.filename, 'rb'))
-        url = reverse(
-            'admin:filer-ajax_upload',
-            kwargs={'folder_id': folder.pk}
-        ) + '?filename=%s' % self.image_name
-        response = self.client.post(  # noqa
-            url,
-            data=file_obj.read(),
-            content_type='image/jpeg',
-            **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
-        )
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
+            url = reverse(
+                'admin:filer-ajax_upload',
+                kwargs={'folder_id': folder.pk}
+            ) + '?filename=%s' % self.image_name
+            response = self.client.post(  # noqa
+                url,
+                data=file_obj.read(),
+                content_type='image/jpeg',
+                **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
+            )
         self.assertEqual(Image.objects.count(), 1)
         stored_image = Image.objects.first()
         self.assertEqual(stored_image.original_filename, self.image_name)
@@ -356,17 +362,18 @@ class FilerClipboardAdminUrlsTests(TestCase):
     def test_filer_ajax_upload_file_using_content_type(self):
         self.assertEqual(Image.objects.count(), 0)
         folder = Folder.objects.create(name='foo')
-        file_obj = django.core.files.File(open(self.binary_filename, 'rb'))
-        url = reverse(
-            'admin:filer-ajax_upload',
-            kwargs={'folder_id': folder.pk}
-        ) + '?filename=renamed.pdf'
-        response = self.client.post(  # noqa
-            url,
-            data=file_obj.read(),
-            content_type='application/pdf',
-            **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
-        )
+        with open(self.binary_filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
+            url = reverse(
+                'admin:filer-ajax_upload',
+                kwargs={'folder_id': folder.pk}
+            ) + '?filename=renamed.pdf'
+            response = self.client.post(  # noqa
+                url,
+                data=file_obj.read(),
+                content_type='application/pdf',
+                **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
+            )
         self.assertEqual(Image.objects.count(), 0)
         self.assertEqual(File.objects.count(), 1)
         stored_file = File.objects.first()
@@ -375,16 +382,17 @@ class FilerClipboardAdminUrlsTests(TestCase):
 
     def test_filer_ajax_upload_file_no_folder(self):
         self.assertEqual(Image.objects.count(), 0)
-        file_obj = django.core.files.File(open(self.filename, 'rb'))
-        url = reverse(
-            'admin:filer-ajax_upload'
-        ) + '?filename=%s' % self.image_name
-        response = self.client.post(  # noqa
-            url,
-            data=file_obj.read(),
-            content_type='image/jpeg',
-            **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
-        )
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
+            url = reverse(
+                'admin:filer-ajax_upload'
+            ) + '?filename=%s' % self.image_name
+            response = self.client.post(  # noqa
+                url,
+                data=file_obj.read(),
+                content_type='image/jpeg',
+                **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
+            )
         self.assertEqual(Image.objects.count(), 1)
         stored_image = Image.objects.first()
         self.assertEqual(stored_image.original_filename, self.image_name)
@@ -393,15 +401,16 @@ class FilerClipboardAdminUrlsTests(TestCase):
     def test_filer_upload_file_error(self, extra_headers={}):
         self.assertEqual(Image.objects.count(), 0)
         folder = Folder.objects.create(name='foo')
-        file_obj = django.core.files.File(open(self.filename, 'rb'))
-        url = reverse('admin:filer-ajax_upload',
-                      kwargs={'folder_id': folder.pk + 1})
-        post_data = {
-            'Filename': self.image_name,
-            'Filedata': file_obj,
-            'jsessionid': self.client.session.session_key
-        }
-        response = self.client.post(url, post_data, **extra_headers)
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
+            url = reverse('admin:filer-ajax_upload',
+                          kwargs={'folder_id': folder.pk + 1})
+            post_data = {
+                'Filename': self.image_name,
+                'Filedata': file_obj,
+                'jsessionid': self.client.session.session_key
+            }
+            response = self.client.post(url, post_data, **extra_headers)
         from filer.admin.clipboardadmin import NO_FOLDER_ERROR
         self.assertContains(response, NO_FOLDER_ERROR)
         self.assertEqual(Image.objects.count(), 0)
@@ -409,18 +418,19 @@ class FilerClipboardAdminUrlsTests(TestCase):
     def test_filer_ajax_upload_file_error(self):
         self.assertEqual(Image.objects.count(), 0)
         folder = Folder.objects.create(name='foo')
-        file_obj = django.core.files.File(open(self.filename, 'rb'))
-        url = reverse(
-            'admin:filer-ajax_upload',
-            kwargs={
-                'folder_id': folder.pk + 1}
-        ) + '?filename={0}'.format(self.image_name)
-        response = self.client.post(
-            url,
-            data=file_obj.read(),
-            content_type='application/octet-stream',
-            **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
-        )
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
+            url = reverse(
+                'admin:filer-ajax_upload',
+                kwargs={
+                    'folder_id': folder.pk + 1}
+            ) + '?filename={0}'.format(self.image_name)
+            response = self.client.post(
+                url,
+                data=file_obj.read(),
+                content_type='application/octet-stream',
+                **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
+            )
         from filer.admin.clipboardadmin import NO_FOLDER_ERROR
         self.assertContains(response, NO_FOLDER_ERROR)
         self.assertEqual(Image.objects.count(), 0)
@@ -435,26 +445,27 @@ class FilerClipboardAdminUrlsTests(TestCase):
         self.client.login(username='joe_new', password='x')
         self.assertEqual(Image.objects.count(), 0)
         folder = Folder.objects.create(name='foo')
-        file_obj = django.core.files.File(open(self.filename, 'rb'))
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
 
-        with SettingsOverride(filer_settings, FILER_ENABLE_PERMISSIONS=True):
+            with SettingsOverride(filer_settings, FILER_ENABLE_PERMISSIONS=True):
 
-            # give permissions over BAR
-            FolderPermission.objects.create(
-                folder=folder,
-                user=staff_user,
-                type=FolderPermission.THIS,
-                can_edit=FolderPermission.DENY,
-                can_read=FolderPermission.ALLOW,
-                can_add_children=FolderPermission.DENY)
-            url = reverse('admin:filer-ajax_upload',
-                          kwargs={'folder_id': folder.pk})
-            post_data = {
-                'Filename': self.image_name,
-                'Filedata': file_obj,
-                'jsessionid': self.client.session.session_key
-            }
-            response = self.client.post(url, post_data, **extra_headers)
+                # give permissions over BAR
+                FolderPermission.objects.create(
+                    folder=folder,
+                    user=staff_user,
+                    type=FolderPermission.THIS,
+                    can_edit=FolderPermission.DENY,
+                    can_read=FolderPermission.ALLOW,
+                    can_add_children=FolderPermission.DENY)
+                url = reverse('admin:filer-ajax_upload',
+                              kwargs={'folder_id': folder.pk})
+                post_data = {
+                    'Filename': self.image_name,
+                    'Filedata': file_obj,
+                    'jsessionid': self.client.session.session_key
+                }
+                response = self.client.post(url, post_data, **extra_headers)
 
         from filer.admin.clipboardadmin import NO_PERMISSIONS_FOR_FOLDER
         self.assertContains(response, NO_PERMISSIONS_FOR_FOLDER)
@@ -470,19 +481,20 @@ class FilerClipboardAdminUrlsTests(TestCase):
         self.client.login(username='joe_new', password='x')
         self.assertEqual(Image.objects.count(), 0)
         folder = Folder.objects.create(name='foo')
-        file_obj = django.core.files.File(open(self.filename, 'rb'))
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
 
-        url = reverse(
-            'admin:filer-ajax_upload',
-            kwargs={
-                'folder_id': folder.pk}
-        ) + '?filename={0}'.format(self.image_name)
-        response = self.client.post(
-            url,
-            data=file_obj.read(),
-            content_type='application/octet-stream',
-            **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
-        )
+            url = reverse(
+                'admin:filer-ajax_upload',
+                kwargs={
+                    'folder_id': folder.pk}
+            ) + '?filename={0}'.format(self.image_name)
+            response = self.client.post(
+                url,
+                data=file_obj.read(),
+                content_type='application/octet-stream',
+                **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
+            )
 
         from filer.admin.clipboardadmin import NO_PERMISSIONS
 
@@ -499,29 +511,31 @@ class FilerClipboardAdminUrlsTests(TestCase):
         self.client.login(username='joe_new', password='x')
         self.assertEqual(Image.objects.count(), 0)
         folder = Folder.objects.create(name='foo')
-        file_obj = django.core.files.File(open(self.filename, 'rb'))
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh)
 
-        with SettingsOverride(filer_settings, FILER_ENABLE_PERMISSIONS=True):
+            with SettingsOverride(filer_settings, FILER_ENABLE_PERMISSIONS=True):
 
-            # give permissions over BAR
-            FolderPermission.objects.create(
-                folder=folder,
-                user=staff_user,
-                type=FolderPermission.THIS,
-                can_edit=FolderPermission.DENY,
-                can_read=FolderPermission.ALLOW,
-                can_add_children=FolderPermission.DENY)
-            url = reverse(
-                'admin:filer-ajax_upload',
-                kwargs={
-                    'folder_id': folder.pk}
-            ) + '?filename={0}'.format(self.image_name)
-            response = self.client.post(
-                url,
-                data=file_obj.read(),
-                content_type='application/octet-stream',
-                **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
-            )
+                # give permissions over BAR
+                FolderPermission.objects.create(
+                    folder=folder,
+                    user=staff_user,
+                    type=FolderPermission.THIS,
+                    can_edit=FolderPermission.DENY,
+                    can_read=FolderPermission.ALLOW,
+                    can_add_children=FolderPermission.DENY)
+                url = reverse(
+                    'admin:filer-ajax_upload',
+                    kwargs={
+                        'folder_id': folder.pk}
+                ) + '?filename={0}'.format(self.image_name)
+                response = self.client.post(
+                    url,
+                    data=file_obj.read(),
+                    content_type='application/octet-stream',
+                    **{'HTTP_X_REQUESTED_WITH': 'XMLHttpRequest'}
+                )
+
         from filer.admin.clipboardadmin import NO_PERMISSIONS_FOR_FOLDER
         self.assertContains(response, NO_PERMISSIONS_FOR_FOLDER)
         self.assertEqual(Image.objects.count(), 0)
@@ -530,9 +544,10 @@ class FilerClipboardAdminUrlsTests(TestCase):
         filename = os.path.join(settings.FILE_UPLOAD_TEMP_DIR, 'invalid.svg')
         with open(filename, 'wb') as fh:
             fh.write(b'<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg" height="0" width="0"><circle cx="0" cy="0" r="0" stroke="black" stroke-width="3" fill="red" /></svg>')
-        file_obj = django.core.files.File(open(filename, 'rb'), name=filename)
-        image_obj = Image.objects.create(owner=self.superuser, original_filename=self.image_name, file=file_obj, mime_type='image/svg+xml')
-        image_obj.save()
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh, name=filename)
+            image_obj = Image.objects.create(owner=self.superuser, original_filename=self.image_name, file=file_obj, mime_type='image/svg+xml')
+            image_obj.save()
         url = file_icon_url(image_obj)
         self.assertEqual(url, '/static/filer/icons/file\\u002Dunknown.svg')
 
@@ -576,9 +591,10 @@ class BulkOperationsMixin:
 
     def create_image(self, folder, filename=None):
         filename = filename or 'test_image.jpg'
-        file_obj = django.core.files.File(open(self.filename, 'rb'), name=filename)
-        image_obj = Image.objects.create(owner=self.superuser, original_filename=self.image_name, file=file_obj, folder=folder, mime_type='image/jpeg')
-        image_obj.save()
+        with open(self.filename, 'rb') as fh:
+            file_obj = django.core.files.File(fh, name=filename)
+            image_obj = Image.objects.create(owner=self.superuser, original_filename=self.image_name, file=file_obj, folder=folder, mime_type='image/jpeg')
+            image_obj.save()
         return image_obj
 
     def create_file(self, folder, filename=None):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -489,7 +489,6 @@ class FilerClipboardAdminUrlsTests(TestCase):
         self.assertContains(response, NO_PERMISSIONS)
         self.assertEqual(Image.objects.count(), 0)
 
-
     def test_filer_ajax_upload_permissions_error(self, extra_headers={}):
         self.client.logout()
         staff_user = User.objects.create_user(

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -259,7 +259,8 @@ class FilerClipboardAdminUrlsTests(TestCase):
                 'Filedata': file_obj,
                 'jsessionid': self.client.session.session_key
             }
-            response = self.client.post(url, post_data, **extra_headers)  # noqa
+            self.client.post(url, post_data, **extra_headers)  # noqa
+
         self.assertEqual(Image.objects.count(), 1)
         self.assertEqual(Image.objects.all()[0].original_filename,
                          self.image_name)
@@ -281,7 +282,8 @@ class FilerClipboardAdminUrlsTests(TestCase):
                     'Filedata': file_obj,
                     'jsessionid': self.client.session.session_key
                 }
-                response = self.client.post(url, post_data, **extra_headers)  # noqa
+                self.client.post(url, post_data, **extra_headers)  # noqa
+
             self.assertEqual(Video.objects.count(), 1)
             self.assertEqual(Video.objects.all()[0].original_filename, self.video_name)
 
@@ -302,7 +304,8 @@ class FilerClipboardAdminUrlsTests(TestCase):
                     'Filedata': file_obj,
                     'jsessionid': self.client.session.session_key
                 }
-                response = self.client.post(url, post_data, **extra_headers)  # noqa
+                self.client.post(url, post_data, **extra_headers)  # noqa
+
             self.assertEqual(ExtImage.objects.count(), 1)
             self.assertEqual(ExtImage.objects.all()[0].original_filename, self.image_name)
 
@@ -332,7 +335,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
                 'Filedata': file_obj,
                 'jsessionid': self.client.session.session_key
             }
-            response = self.client.post(url, post_data, **extra_headers)  # noqa
+            self.client.post(url, post_data, **extra_headers)  # noqa
             self.assertEqual(Image.objects.count(), 0)
             self.assertEqual(File.objects.count(), 1)
             stored_file = File.objects.first()
@@ -368,7 +371,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
                 'admin:filer-ajax_upload',
                 kwargs={'folder_id': folder.pk}
             ) + '?filename=renamed.pdf'
-            response = self.client.post(  # noqa
+            self.client.post(  # noqa
                 url,
                 data=file_obj.read(),
                 content_type='application/pdf',
@@ -387,7 +390,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
             url = reverse(
                 'admin:filer-ajax_upload'
             ) + '?filename=%s' % self.image_name
-            response = self.client.post(  # noqa
+            self.client.post(  # noqa
                 url,
                 data=file_obj.read(),
                 content_type='image/jpeg',

--- a/tests/test_dump.py
+++ b/tests/test_dump.py
@@ -35,17 +35,19 @@ class DumpDataTests(TestCase):
         pass
 
     def create_filer_image(self, folder=None):
-        file_obj = DjangoFile(open(self.filename, 'rb'), name=self.image_name)
-        image = Image.objects.create(owner=self.superuser,
-                                     original_filename=self.image_name,
-                                     file=file_obj, folder=folder)
+        with open(self.filename, 'rb') as file:
+            file_obj = DjangoFile(file, name=self.image_name)
+            image = Image.objects.create(owner=self.superuser,
+                                         original_filename=self.image_name,
+                                         file=file_obj, folder=folder)
         return image
 
     def create_filer_file(self, folder=None):
-        file_obj = DjangoFile(open(self.filename, 'rb'), name=self.image_name)
-        fileobj = File.objects.create(owner=self.superuser,
-                                      original_filename=self.image_name,
-                                      file=file_obj, folder=folder)
+        with open(self.filename, 'rb') as file:
+            file_obj = DjangoFile(file, name=self.image_name)
+            fileobj = File.objects.create(owner=self.superuser,
+                                          original_filename=self.image_name,
+                                          file=file_obj, folder=folder)
         return fileobj
 
     def test_dump_data_base(self):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,7 +1,7 @@
 import os
 
 from django.conf import settings
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.core.files import File as DjangoFile
 from django.test.testcases import TestCase
 
@@ -33,8 +33,11 @@ class FolderPermissionsTestCase(TestCase):
 
         self.owner = User.objects.create(username='owner')
 
+        perms = Permission.objects.filter(codename="change_folder")
         self.test_user1 = User.objects.create(username='test1', password='secret')
         self.test_user2 = User.objects.create(username='test2', password='secret')
+        self.test_user1.user_permissions.add(*perms)
+        self.test_user2.user_permissions.add(*perms)
 
         self.group1 = Group.objects.create(name='name1')
         self.group2 = Group.objects.create(name='name2')

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -35,6 +35,7 @@ class ToolsTestCase(TestCase):
         self.folder = Folder.objects.create(name='test_folder')
 
     def tearDown(self):
+        self.file.close()
         self.client.logout()
         os.remove(self.filename)
         for img in Image.objects.all():


### PR DESCRIPTION
## Description

This PR fixes a **security issue**: A **staff user without any permissions** 
* Can browse the filer folder structure 
* List files in a folder
* Add files
* Move files and folders

Thanks to Akshar Tank for reporting this issue.

## Fix

This fix enforces the following permissions
* `can_use_directory_listing` 
* `change_folder`
* `add_folder`
* `add_file`(also for drag&drop upload)

## Desired side effects

* Users need to have the permission `add_file` to upload files
* Users need to have the permission `can_use_directory_listing` to browse the filer folders
* 
## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
