### PR TITLE
fix: File.objects.only("id") query when deleting a user

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+unreleased
+==========
+
+* Fix File.objects.only() query required for deleting user who own files.
+
 2.2.4 (2023-01-13)
 ==================
 * Add Django 4.1 support

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -13,6 +13,7 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from polymorphic.managers import PolymorphicManager
+from polymorphic.query import PolymorphicQuerySet
 from polymorphic.models import PolymorphicModel
 
 from .. import settings as filer_settings
@@ -21,7 +22,16 @@ from . import mixins
 from .foldermodels import Folder
 
 
+class FileQuerySet(PolymorphicQuerySet):
+    def only(self, *fields):
+        fields = set(fields)
+        fields.update(["_file_size", "sha1", "is_public"])
+        return super().only(*fields)
+
+
 class FileManager(PolymorphicManager):
+    queryset_class = FileQuerySet
+
     def find_all_duplicates(self):
         r = {}
         for file_obj in self.all():

--- a/filer/static/filer/js/base.js
+++ b/filer/static/filer/js/base.js
@@ -98,7 +98,7 @@ Cl.mediator = new Mediator();
 
             actionSelect.on('change', function () {
                 // Mark element selected (for table view this is done by Django admin js - we do it ourselves
-                if ($(this).prop("checked")) {
+                if ($(this).prop('checked')) {
                     $(this).closest('.list-item').addClass('selected');
                 } else {
                     $(this).closest('.list-item').removeClass('selected');

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -35,9 +35,11 @@ class FilerApiTests(TestCase):
         for f in File.objects.all():
             f.delete()
 
-    def create_filer_image(self):
+    def create_filer_image(self, owner=None):
+        if owner is None:
+            owner = self.superuser
         file_obj = DjangoFile(open(self.filename, 'rb'), name=self.image_name)
-        image = Image.objects.create(owner=self.superuser,
+        image = Image.objects.create(owner=owner,
                                      original_filename=self.image_name,
                                      file=file_obj)
         return image
@@ -307,3 +309,22 @@ class FilerApiTests(TestCase):
         image.save()
         canonical = image.canonical_url
         self.assertTrue(canonical.startswith('/filer/test-path/'))
+
+    def test_delete_user_who_owns_file(self):
+        """Tests if deleting users who own files works"""
+        from django.contrib.auth.models import User
+
+        user = User.objects.create(
+            username="test",
+            password="top-secret",
+            email="community-hero@django-cms.org",
+            is_staff=True,
+        )
+        image = self.create_filer_image(user)
+
+        user.delete()
+
+        # User needs to be gone
+        self.assertEqual(len(User.objects.filter(username="test")), 0)
+        # Image remains w/o owner
+        self.assertIsNone(File.objects.get(pk=image.pk).owner)


### PR DESCRIPTION
## Description

> This PR is a cherry-pick of #1308 plus a simple test to verify that deleting users work. **Thank you @wiltso for providing this fix!**

When deleting a User object, Django's `django.db.models.deletion.Collector` will make a query like this: `File.objects.filter(owner=user).only("id")`.
This then leads to a recursion error due to that the `filer.models.File` object requires that the following fields are present:
- `_file_size`
- `sha1`
- `is_public`

## Related resources

- #1308
- https://github.com/django-cms/django-filer/issues/1290

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
