### PR TITLE
fix: search in this folder only crashes (500)

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -306,7 +306,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             else:
                 folder_qs = self.get_queryset(request)
                 file_qs = File.objects.all()
-            folder_qs = self.filter_folder(folder_qs, search_terms).prefetch_related("children", "files")
+            folder_qs = self.filter_folder(folder_qs, search_terms).prefetch_related("children", "all_files")
             file_qs = self.filter_file(file_qs, search_terms)
 
             show_result_count = True

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -297,16 +297,16 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
 
         if len(search_terms) > 0:
             if folder and limit_search_to_folder and not folder.is_root:
+                desc_folder_ids = folder.get_descendants_ids()
                 # Do not include current folder itself in search results.
-                folder_qs = folder.get_descendants(include_self=False)
+                folder_qs = Folder.objects.filter(pk__in=desc_folder_ids)
                 # Limit search results to files in the current folder or any
                 # nested folder.
-                file_qs = File.objects.filter(
-                    folder__in=folder.get_descendants(include_self=True))
+                file_qs = File.objects.filter(folder_id__in=desc_folder_ids + [folder.pk])
             else:
                 folder_qs = self.get_queryset(request)
                 file_qs = File.objects.all()
-            folder_qs = self.filter_folder(folder_qs, search_terms)
+            folder_qs = self.filter_folder(folder_qs, search_terms).prefetch_related("children", "files")
             file_qs = self.filter_file(file_qs, search_terms)
 
             show_result_count = True

--- a/filer/templates/admin/filer/folder/directory_listing.html
+++ b/filer/templates/admin/filer/folder/directory_listing.html
@@ -146,7 +146,7 @@
                                 <input type="text" placeholder="{% trans 'Search' %}" class="filter-files-field js-filter-files" value="{{ search_string }}" name="q">
                                 <div class="filer-dropdown-container filer-dropdown-container-down">
                                     <a href="#" data-toggle="filer-dropdown" aria-expanded="false">
-                                        <span class="fa fa-caret-down cms-icon cms-filer-icon-caret-down"></span>
+                                        <span class="filer-icon filer-icon-caret-down fa fa-caret-down"></span>
                                     </a>
                                 </div>
                                 <ul class="filer-dropdown-menu filer-dropdown-menu-checkboxes">


### PR DESCRIPTION
## Description

When selecting "Search in this folder only" in a non-root folder, the search crashes. 

Also adds a prefetch to optimize folder db hits (only minor improvement).

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
