### PR TITLE
fix: Update manifest to exclude mptt stub in release package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
 include LICENSE
 include README.rst
+exclude mptt/__init__.py
 recursive-include filer/locale *
 recursive-include filer/static *
 recursive-include filer/templates *
 recursive-exclude * *.py[co]
-recusrive-exclude mptt *
 recursive-exclude tests *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ recursive-include filer/static *
 recursive-include filer/templates *
 recursive-exclude * *.py[co]
 recusrive-exclude mptt *
+recursive-exclude tests *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ recursive-include filer/locale *
 recursive-include filer/static *
 recursive-include filer/templates *
 recursive-exclude * *.py[co]
+recusrive-exclude mptt *

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -1,10 +1,10 @@
 import logging
 
-import easy_thumbnails.utils
 from django.db import models
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
+import easy_thumbnails.utils
 from easy_thumbnails.VIL import Image as VILImage
 
 from .. import settings as filer_settings


### PR DESCRIPTION
## Description

The repo contains an empty mptt stub since app-helper automatically adds it to `INSTALLED_APPS` for test runs. Tests would fail w/o a (potentially empty) mptt package.

The manifest now excludes the stub from the filer package to not interfere with installations that need django-mptt for other reasons.

The mptt stub can be removed from the django-filer repo once app-helper is updated.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* https://github.com/nephila/django-app-helper/pull/224
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
