### PR TITLE
Fix: Remove unused icon libraries in django-filer 3.0.0rc1

### DIFF
--- a/filer/templates/admin/filer/delete_confirmation.html
+++ b/filer/templates/admin/filer/delete_confirmation.html
@@ -1,9 +1,8 @@
 {% extends "admin/delete_confirmation.html" %}
-{% load i18n static filer_admin_tags %}
+{% load i18n static %}
 
 {% block extrastyle %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'filer/css/admin_filer.css' %}">
-    {% icon_css_library %}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/filer/templates/admin/filer/delete_confirmation.html
+++ b/filer/templates/admin/filer/delete_confirmation.html
@@ -1,9 +1,9 @@
 {% extends "admin/delete_confirmation.html" %}
-{% load i18n static %}
+{% load i18n static filer_admin_tags %}
 
 {% block extrastyle %}{{ block.super }}
-    <link rel="stylesheet" type="text/css" href="{% static 'filer/css/admin_filer.icons.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'filer/css/admin_filer.css' %}">
+    {% icon_css_library %}
 {% endblock %}
 
 {% block breadcrumbs %}

--- a/filer/templates/admin/filer/folder/choose_move_destination.html
+++ b/filer/templates/admin/filer/folder/choose_move_destination.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n static %}
+{% load i18n static filer_admin_tags %}
 
 {% block breadcrumbs %}
     {% include "admin/filer/breadcrumbs.html" %}
@@ -8,8 +8,8 @@
 {% block extrastyle %}
     {{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">
-    <link rel="stylesheet" type="text/css" href="{% static 'filer/css/admin_filer.icons.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'filer/css/admin_filer.css' %}">
+    {% icon_css_library %}
 {% endblock %}
 
 {% block extrahead %}

--- a/filer/templates/admin/filer/folder/choose_move_destination.html
+++ b/filer/templates/admin/filer/folder/choose_move_destination.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n static filer_admin_tags %}
+{% load i18n static %}
 
 {% block breadcrumbs %}
     {% include "admin/filer/breadcrumbs.html" %}
@@ -9,7 +9,6 @@
     {{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'filer/css/admin_filer.css' %}">
-    {% icon_css_library %}
 {% endblock %}
 
 {% block extrahead %}


### PR DESCRIPTION
## Description

Testing django-filer 3.0.0rc1 revealed that for "move file" and "delete file" an outdated, unused icon library css is requested. This leads to either a 404 or a 500 (with manifest file storage).

This PR updates the relevant templates.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
