### PR TITLE
Feat: add heif upload support (`*.heic`, e.g., for iOS devices)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ CHANGELOG
 * Add an edit button to the file widget which opens edit file pop-up
 * Refactored directory list view for significant performance increases
 * Remove thumbnail generation from the directory list view request response cycle
+* Support for upload of webp images
+* Optional support for upload of heif images
 * Add Django 4.2 support
 * Add thumbnail view for faster visual management of image libraries
 * Fix File.objects.only() query required for deleting user who own files.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,6 +10,14 @@ The easiest way to get ``django-filer`` is simply install it with `pip`_::
 
     $ pip install django-filer
 
+Optional heic support
+---------------------
+
+Currently, django-filer supports upload of heif images (``*.heic``, such as
+retrieved from iOS devices by airdrop) using an optional dependency::
+
+    $ pip install django-filer\[heif\]
+
 
 Dependencies
 ------------
@@ -30,6 +38,11 @@ check `Pillow doc`_.
 * for `Django`_ >=2.2 use `django-polymorphic`_ >=2.0
 * for `Django`_ >=3.0 use `django-polymorphic`_ >=2.1
 * for `Django`_ >=3.1 use `django-polymorphic`_ >=3.0
+
+If heif support is chosen, django-filer also installs
+
+* pillow-heif
+
 
 Configuration
 -------------

--- a/filer/apps.py
+++ b/filer/apps.py
@@ -9,7 +9,7 @@ class FilerConfig(AppConfig):
     verbose_name = _("Filer")
 
     def register_optional_heif_supprt(self):
-        try:
+        try:  # pragma:  no cover
             from pillow_heif import register_heif_opener
 
             from .settings import IMAGE_EXTENSIONS, IMAGE_MIME_TYPES

--- a/filer/apps.py
+++ b/filer/apps.py
@@ -11,6 +11,7 @@ class FilerConfig(AppConfig):
     def register_optional_heif_supprt(self):
         try:
             from pillow_heif import register_heif_opener
+
             from .settings import IMAGE_EXTENSIONS, IMAGE_MIME_TYPES
 
             register_heif_opener()

--- a/filer/apps.py
+++ b/filer/apps.py
@@ -8,7 +8,19 @@ class FilerConfig(AppConfig):
     name = 'filer'
     verbose_name = _("Filer")
 
-    def ready(self):
+    def register_optional_heif_supprt(self):
+        try:
+            from pillow_heif import register_heif_opener
+            from .settings import IMAGE_EXTENSIONS, IMAGE_MIME_TYPES
+
+            register_heif_opener()
+            IMAGE_EXTENSIONS += [".heic", ".heics", ".heif", ".heifs", ".hif"]
+            IMAGE_MIME_TYPES.append("heic")
+        except (ModuleNotFoundError, ImportError):
+            # No heif support installed
+            pass
+
+    def resolve_validators(self):
         """Resolve dotted path file validators"""
 
         import importlib
@@ -37,3 +49,7 @@ class FilerConfig(AppConfig):
                     except (ImportError, ModuleNotFoundError, AttributeError):
                         raise ImproperlyConfigured(f"""filer: could not import validator "{item}".""")
             self.FILE_VALIDATORS[mime_type] = functions
+
+    def ready(self):
+        self.resolve_validators()
+        self.register_optional_heif_supprt()

--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -25,11 +25,12 @@ class FileImporter:
         """
         Create a File or an Image into the given folder
         """
+        from ...settings import IMAGE_EXTENSIONS
         try:
             iext = os.path.splitext(file_obj.name)[1].lower()
         except:  # noqa
             iext = ''
-        if iext in ['.jpg', '.jpeg', '.png', '.gif', '.webp']:
+        if iext in IMAGE_EXTENSIONS:
             obj, created = Image.objects.get_or_create(
                 original_filename=file_obj.name,
                 file=file_obj,

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -83,9 +83,9 @@ class BaseImage(File):
     @classmethod
     def matches_file_type(cls, iname, ifile, mime_type):
         # source: https://www.freeformatter.com/mime-types-list.html
-        image_subtypes = ['gif', 'jpeg', 'png', 'x-png', 'svg+xml', 'webp']
+        from ..settings import IMAGE_MIME_TYPES
         maintype, subtype = mime_type.split('/')
-        return maintype == 'image' and subtype in image_subtypes
+        return maintype == 'image' and subtype in IMAGE_MIME_TYPES
 
     def file_data_changed(self, post_init=False):
         attrs_updated = super().file_data_changed(post_init=post_init)

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -281,6 +281,8 @@ FILER_FOLDER_ADMIN_LIST_TYPE_SWITCHER_SETTINGS = {
 }
 
 DEFERRED_THUMBNAIL_SIZES = (40, 80, 160)
+IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp']
+IMAGE_MIME_TYPES = ['gif', 'jpeg', 'png', 'x-png', 'svg+xml', 'webp']
 
 FILE_VALIDATORS = {
     "text/html": ["filer.validation.deny_html"],

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,13 @@ REQUIREMENTS = [
 ]
 
 
+EXTRA_REQUIREMENTS = {
+    "heif": [
+        "pillow-heif",
+    ],
+}
+
+
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
     'Environment :: Web Environment',
@@ -61,6 +68,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=REQUIREMENTS,
+    extras_require=EXTRA_REQUIREMENTS,
     python_requires='>=3.8',
     classifiers=CLASSIFIERS,
     test_suite='tests.settings.run',

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -1,5 +1,5 @@
 # requirements from setup.py
-Pillow
+Pillow<10  # Remove pinning for 3.0.0 release
 
 # other requirements
 coverage


### PR DESCRIPTION
## Description

This PR adds optional support for upload. To activate, install using `pip install django-filer\[heif\]`.

This installs `pillow-heif`.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
