### PR TITLE
fix: issues with filer image crash when trying to generate thumbnail

### DIFF
--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -181,7 +181,7 @@ class FileAdmin(PrimitivePermissionAwareModelAdmin):
             thumbnail = thumbnailer.get_thumbnail(thumbnail_options, generate=True)
             return HttpResponseRedirect(thumbnail.url)
         except InvalidImageFormatError:
-            raise Http404
+            return HttpResponseRedirect(staticfiles_storage.url('filer/icons/file-missing.svg'))
 
 
 FileAdmin.fieldsets = FileAdmin.build_fieldsets()

--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 
 from easy_thumbnails.files import get_thumbnailer
 from easy_thumbnails.options import ThumbnailOptions
+from easy_thumbnails.exceptions import InvalidImageFormatError
 
 from .. import settings
 from ..models import BaseImage, File
@@ -174,10 +175,13 @@ class FileAdmin(PrimitivePermissionAwareModelAdmin):
         if not isinstance(file, BaseImage):
             raise Http404()
 
-        thumbnailer = get_thumbnailer(file)
-        thumbnail_options = ThumbnailOptions({'size': (size, size), "crop": True})
-        thumbnail = thumbnailer.get_thumbnail(thumbnail_options, generate=True)
-        return HttpResponseRedirect(thumbnail.url)
+        try:
+            thumbnailer = get_thumbnailer(file)
+            thumbnail_options = ThumbnailOptions({'size': (size, size), "crop": True})
+            thumbnail = thumbnailer.get_thumbnail(thumbnail_options, generate=True)
+            return HttpResponseRedirect(thumbnail.url)
+        except InvalidImageFormatError:
+            raise Http404
 
 
 FileAdmin.fieldsets = FileAdmin.build_fieldsets()


### PR DESCRIPTION
Thumbnail generation can fail when the image is not present or moved or if we have a reference in database but no image in storage.


- Github Issue: Fixes  #1379


## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
