### PR TITLE
fix: try and prevent crash from missing file when thumbnailing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 CHANGELOG
 =========
 
+
+3.0.2 (2023-07-14)
+==================
+
+* Fix another crash in thumbnailing when the image is missing from the storage
+  source but has a reference in the database.
+
+
 3.0.1 (2023-07-13)
 ==================
 

--- a/filer/__init__.py
+++ b/filer/__init__.py
@@ -13,6 +13,6 @@ Release logic:
  8. Publish the release and it will automatically release to pypi
 """
 
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 
 default_app_config = 'filer.apps.FilerConfig'


### PR DESCRIPTION
## Description

Fix crash in filer performing easy-thumbnails thumb-nailing when for some reason the image is not present.

An earlier fix #1379 was done, but it didn't take care of all edge cases, but this one does and gracefully rescues the error and at the same time provides a fallback.

## Related resources



## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
