### PR TITLE
fix: Prevent server errors in image detail view if images do not exist

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -298,6 +298,21 @@ class FilerImageAdminUrlsTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("icons/file-missing.svg", response["Location"])
 
+    def test_icon_view_non_image(self):
+        """Getting an icon for a non-image results in a 404"""
+        file = File.objects.create(
+            owner=self.superuser,
+            original_filename="some-file.xyz",
+        )
+        url = reverse('admin:filer_file_fileicon', kwargs={
+            'file_id': file.pk,
+            'size': 80,
+        })
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 404)
+
     def test_detail_view_missing_file(self):
         """Detail view shows static icon for missing file"""
         image = Image.objects.create(

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -266,7 +266,7 @@ class FilerImageAdminUrlsTests(TestCase):
         os.remove(self.filename)
 
     def test_icon_view_sizes(self):
-        """Tests if redirects are issued for accepted thumbnail sizes and 404 otherwise"""
+        """Redirects are issued for accepted thumbnail sizes and 404 otherwise"""
         test_set = tuple((size, 302) for size in DEFERRED_THUMBNAIL_SIZES)
         test_set += (50, 404), (90, 404), (320, 404)
         for size, expected_status in test_set:
@@ -283,6 +283,7 @@ class FilerImageAdminUrlsTests(TestCase):
                 self.assertNotIn("/static/", response["Location"])
 
     def test_missing_file(self):
+        """Directory shows static icon for missing files"""
         image = Image.objects.create(
             owner=self.superuser,
             original_filename="some-image.jpg",
@@ -291,12 +292,32 @@ class FilerImageAdminUrlsTests(TestCase):
             'file_id': image.pk,
             'size': 80,
         })
-        # Make file unaccessible
 
         response = self.client.get(url)
 
         self.assertEqual(response.status_code, 302)
         self.assertIn("icons/file-missing.svg", response["Location"])
+
+    def test_detail_view_missing_file(self):
+        """Detail view shows static icon for missing file"""
+        image = Image.objects.create(
+            owner=self.superuser,
+            original_filename="some-image.jpg",
+        )
+        image._width = 50
+        image._height = 200
+        image.save()
+
+        url = reverse('admin:filer_image_change', kwargs={
+            'object_id': image.pk,
+        })
+
+        response = self.client.get(url)
+
+        self.assertContains(response, "icons/file-missing.svg")
+        self.assertContains(response, 'width="210"')
+        self.assertContains(response, 'height="210"')
+        self.assertContains(response, 'alt="File is missing"')
 
 
 class FilerClipboardAdminUrlsTests(TestCase):


### PR DESCRIPTION
## Description

Fix crash in filer performing easy-thumbnails thumb-nailing when for some reason the image is not present.

An earlier fix https://github.com/django-cms/django-filer/issues/1379 was done, but it didn't take care of all edge cases, but this one does and gracefully rescues the error and at the same time provides a fallback.

This PR extends #1388 and adds tests.

## Example: Detail view with missing file

![image](https://github.com/django-cms/django-filer/assets/16904477/f0f89ef0-cb4d-45c0-84ca-2e724acef41f)

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #1379
* #1388

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
