### PR TITLE
Fix copy folder being broken after django-mptt removal

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -1076,7 +1076,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
 
         old_folder = Folder.objects.get(pk=folder.pk)
 
-        new_folder = Folder.objects.create(
+        folder, _ = Folder.objects.get_or_create(
             name=foldername,
             owner=old_folder.owner,
             parent=destination,
@@ -1085,10 +1085,10 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         for perm in FolderPermission.objects.filter(folder=old_folder):
             perm.pk = None
             perm.id = None
-            perm.folder = new_folder
+            perm.folder = folder
             perm.save()
 
-        return 1 + self._copy_files_and_folders_impl(old_folder.files.all(), old_folder.children.all(), new_folder, suffix, overwrite)
+        return 1 + self._copy_files_and_folders_impl(old_folder.files.all(), old_folder.children.all(), folder, suffix, overwrite)
 
     def _copy_files_and_folders_impl(self, files_queryset, folders_queryset, destination, suffix, overwrite):
         n = self._copy_files(files_queryset, destination, suffix, overwrite)

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -1076,19 +1076,19 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
 
         old_folder = Folder.objects.get(pk=folder.pk)
 
-        # Due to how inheritance works, we have to set both pk and id to None
-        folder.pk = None
-        folder.id = None
-        folder.name = foldername
-        folder.insert_at(destination, 'last-child', True)  # We save folder here
+        new_folder = Folder.objects.create(
+            name=foldername,
+            owner=old_folder.owner,
+            parent=destination,
+        )
 
         for perm in FolderPermission.objects.filter(folder=old_folder):
             perm.pk = None
             perm.id = None
-            perm.folder = folder
+            perm.folder = new_folder
             perm.save()
 
-        return 1 + self._copy_files_and_folders_impl(old_folder.files.all(), old_folder.children.all(), folder, suffix, overwrite)
+        return 1 + self._copy_files_and_folders_impl(old_folder.files.all(), old_folder.children.all(), new_folder, suffix, overwrite)
 
     def _copy_files_and_folders_impl(self, files_queryset, folders_queryset, destination, suffix, overwrite):
         n = self._copy_files(files_queryset, destination, suffix, overwrite)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -894,6 +894,30 @@ class FilerBulkOperationsTests(BulkOperationsMixin, TestCase):
         dst_image_obj = self.dst_folder.files[0]
         self.assertEqual(dst_image_obj.original_filename, 'test_filetest.jpg')
 
+    def test_copy_folder_action(self):
+        self.assertEqual(self.src_folder.files.count(), 1)
+        self.assertEqual(self.dst_folder.files.count(), 0)
+        self.assertEqual(self.dst_folder.children.count(), 0)
+        self.assertEqual(self.image_obj.original_filename, 'test_file.jpg')
+        url = reverse('admin:filer-directory_listing-root')
+        response = self.client.post(url, {
+            'action': 'copy_files_and_folders',
+            'post': 'yes',
+            'suffix': 'test',
+            'destination': self.dst_folder.id,
+            helpers.ACTION_CHECKBOX_NAME: 'folder-%d' % (self.src_folder.id,),
+        })
+        self.assertEqual(response.status_code, 302)
+
+        self.assertEqual(self.src_folder.files.count(), 1)
+        self.assertEqual(self.dst_folder.files.count(), 0)
+        self.assertEqual(self.dst_folder.children.count(), 1)
+        copied_dir = self.dst_folder.children.first()
+        dst_image_obj = copied_dir.files[0]
+        self.assertEqual(copied_dir.name, self.src_folder.name)
+        self.assertEqual(copied_dir.files.count(), 1)
+        self.assertEqual(dst_image_obj.original_filename, 'test_filetest.jpg')
+
     def _do_test_rename(self, url, new_name, file_obj=None, folder_obj=None):
         """
         Helper to submit rename form and check renaming result.


### PR DESCRIPTION
## Description

After `django-mptt` removal, copying folders is broken because `insert_at` method is not there anymore.
I've added a regression test that should show the error, and then a fix for it that make the test pass.

## Related resources

* #1392 

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
