### PR TITLE
docs: Update dependencies in installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -22,9 +22,9 @@ retrieved from iOS devices by airdrop) using an optional dependency::
 Dependencies
 ------------
 
-* `Django`_ >= 2.2
+* `Django`_ >= 3.2
 * `easy_thumbnails`_ >= 2.0
-* `django-polymorphic`_ >= 0.7
+* `django-polymorphic`_ >= 3.0
 * `Pillow`_ >=2.3.0 (with JPEG and ZLIB support, `PIL`_ may work but is not supported)
 
 ``django.contrib.staticfiles`` is required.
@@ -32,12 +32,6 @@ Dependencies
 Please make sure you install `Pillow`_ with JPEG and  ZLIB support installed;
 for further information on Pillow installation and its binary dependencies,
 check `Pillow doc`_.
-
-`django-polymorphic`_ version depends on `Django`_ version:
-
-* for `Django`_ >=2.2 use `django-polymorphic`_ >=2.0
-* for `Django`_ >=3.0 use `django-polymorphic`_ >=2.1
-* for `Django`_ >=3.1 use `django-polymorphic`_ >=3.0
 
 If heif support is chosen, django-filer also installs
 

--- a/filer/admin/clipboardadmin.py
+++ b/filer/admin/clipboardadmin.py
@@ -140,7 +140,7 @@ def ajax_upload(request, folder_id=None):
             'file_id': file_obj.pk,
         }
         # prepare preview thumbnail
-        if type(file_obj) == Image:
+        if isinstance(file_obj, Image):
             thumbnail_180_options = {
                 'size': (180, 180),
                 'crop': True,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from filer import __version__
 
 
 REQUIREMENTS = [
-    'django>=2.2,<5',
+    'django>=3.2,<5',
     'django-polymorphic',
     'easy-thumbnails[svg]',
 ]


### PR DESCRIPTION
## Description

Filer (since 3.0) is only compatible with Django 3.2+. This is reflected in the readme file, but not yet in the docs themselves.

Additional changes:
* Requirement in setup.py
* Type comparison (flake8 error)

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
