### PR TITLE
fix: remove things related to django 2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 CHANGELOG
 =========
 
+unreleased
+==========
+
+* remove Django 2.2 classifier in setup.py
+* remove tests for Django < 3.2 since those versions are not supported anymore
+
 3.0.4 (2023-08-04)
 ==================
 
@@ -51,6 +57,7 @@ CHANGELOG
 * Remove unused css from delete confirmation view and move file view
 * Add Pillow 10 compatibility
 * Update translations (de/fr/nl)
+* Drop Django 2.2 support
 
 2.2.5 (2023-06-11)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Framework :: Django',
-    'Framework :: Django :: 2.2',
     'Framework :: Django :: 3.0',
     'Framework :: Django :: 3.1',
     'Framework :: Django :: 3.2',

--- a/tests/requirements/django-2.2.txt
+++ b/tests/requirements/django-2.2.txt
@@ -1,4 +1,0 @@
--r base.txt
-
-django>=2.2,<3.0
-django_polymorphic>=2.0,<2.1

--- a/tests/requirements/django-3.0.txt
+++ b/tests/requirements/django-3.0.txt
@@ -1,4 +1,0 @@
--r base.txt
-
-django>=3.0,<3.1
-django_polymorphic>=2.1,<2.2

--- a/tests/requirements/django-3.1.txt
+++ b/tests/requirements/django-3.1.txt
@@ -1,4 +1,0 @@
--r base.txt
-
-django>=3.1,<3.2
-django_polymorphic>=2,<3.1


### PR DESCRIPTION
## Description

* remove Django 2.2 classifier in setup.py
* remove tests for Django < 3.2

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
