### PR TITLE
fix: import_files command to skip existing files

### DIFF
--- a/filer/management/commands/import_files.py
+++ b/filer/management/commands/import_files.py
@@ -31,19 +31,35 @@ class FileImporter:
         except:  # noqa
             iext = ''
         if iext in IMAGE_EXTENSIONS:
-            obj, created = Image.objects.get_or_create(
-                original_filename=file_obj.name,
-                file=file_obj,
-                folder=folder,
-                is_public=FILER_IS_PUBLIC_DEFAULT)
+            try:
+                obj, created = Image.objects.get_or_create(
+                    original_filename=file_obj.name,
+                    folder=folder,
+                    defaults=dict(
+                        file=file_obj,
+                        is_public=FILER_IS_PUBLIC_DEFAULT,
+                    ))
+            except Image.MultipleObjectsReturned:
+                obj, created = Image.objects.filter(
+                    original_filename=file_obj.name,
+                    folder=folder,
+                )[0], False
             if created:
                 self.image_created += 1
         else:
-            obj, created = File.objects.get_or_create(
-                original_filename=file_obj.name,
-                file=file_obj,
-                folder=folder,
-                is_public=FILER_IS_PUBLIC_DEFAULT)
+            try:
+                obj, created = File.objects.get_or_create(
+                    original_filename=file_obj.name,
+                    folder=folder,
+                    defaults=dict(
+                        file=file_obj,
+                        is_public=FILER_IS_PUBLIC_DEFAULT,
+                    ))
+            except File.MultipleObjectsReturned:
+                obj, created = File.objects.filter(
+                    original_filename=file_obj.name,
+                    folder=folder,
+                )[0], False
             if created:
                 self.file_created += 1
         if self.verbosity >= 2:


### PR DESCRIPTION
- Fix use of get_or_create to really skip existing files

## Description

The `import_files` command tries to skip existing files, but it always create new one,
because the way it detects the existing one is wrong.

## Related resources

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
