### PR TITLE
fix: URL action in data table list template

### DIFF
--- a/filer/templates/admin/filer/folder/directory_table_list.html
+++ b/filer/templates/admin/filer/folder/directory_table_list.html
@@ -140,7 +140,6 @@
                             <td class="column-action">
                                 {% if file.canonical_url %}
                                     <a href="{{ file.canonical_url }}" rel="noopener noreferrer"
-                                       download="{{ file.original_filename }}"
                                        title="{% blocktrans with file.label as item_label %}Canonical url '{{ item_label }}'{% endblocktrans %}" class="action-button" target="_blank"><span class="fa fa-link filer-icon filer-icon-link"></span></a>
                                 {% endif %}
                                 <a href="{{ file.url }}" target="_blank" rel="noopener noreferrer"


### PR DESCRIPTION
## Description

In the CMS admin, when listing the files, we have up to 4 action buttons, with the two firsts "URL" & "Download".

Before this [change](https://github.com/django-cms/django-filer/pull/1360/files#diff-714fc9b6a87e4507da2245171743fa7245805d521413cbcfe23074dc80ebe623R143) : Both were links (one canonical, one to the file in media).

Now both are download links.

IMHO :
* the "download" attribute on the "canonical url" action, is a mistake and should not be added.
* the "download" attribute on the "download" action, is a good and correct improvement to the code.

It became more difficult to display the file in the browser without downloading it. (Now only "right click > open url" allows it.)

So this PR fixes this accordingly.

Also, I noted that the feature name adding the bug was "Styling update", but this change was more a behavior update, I think. So I didn't add anything to the changelog of my PR because it's more "going back to the documented state". However, it might be relevant to document somewhere that the previous version added the download attribute on the download link.