### PR TITLE
fix: initialize dropzoneSelector inside inline formsets in a Django 4.1 compatible way

### DIFF
--- a/filer/static/filer/js/addons/dropzone.init.js
+++ b/filer/static/filer/js/addons/dropzone.init.js
@@ -164,7 +164,27 @@ djQuery(function ($) {
         // There is no way to feature detect the new behavior implemented in Django 1.9
         if (!window.__admin_utc_offset__) {
             $(document).on('formset:added', function (ev, row) {
-                var dropzones = $(row).find(dropzoneSelector);
+                if(ev.detail.formsetName) {
+                    /*
+                        Django 4.1 changed the event type being fired when adding
+                        a new formset from a jQuery to a vanilla JavaScript event.
+                        https://docs.djangoproject.com/en/4.1/ref/contrib/admin/javascript/
+
+                        In this case we find the newly added row and initialize the
+                        dropzone on any dropzoneSelector on that row.
+                    */
+                    let rowIdx = parseInt(
+                        document.getElementById(
+                            'id_' + event.detail.formsetName + '-TOTAL_FORMS'
+                        ).value, 10
+                    ) - 1;
+                    let row_ = document.getElementById( event.detail.formsetName + '-' + rowIdx);
+                    var dropzones = $(row_).find(dropzoneSelector)
+
+                } else {
+                    var dropzones = $(row).find(dropzoneSelector);
+                }
+
                 dropzones.each(createDropzone);
             });
         } else {

--- a/filer/static/filer/js/addons/dropzone.init.js
+++ b/filer/static/filer/js/addons/dropzone.init.js
@@ -160,38 +160,31 @@ djQuery(function ($) {
             Dropzone.autoDiscover = false;
         }
         dropzones.each(createDropzone);
-        // window.__admin_utc_offset__ is used as canary to detect Django 1.8
-        // There is no way to feature detect the new behavior implemented in Django 1.9
-        if (!window.__admin_utc_offset__) {
-            $(document).on('formset:added', function (ev, row) {
-                if(ev.detail && ev.detail.formsetName) {
-                    /*
-                        Django 4.1 changed the event type being fired when adding
-                        a new formset from a jQuery to a vanilla JavaScript event.
-                        https://docs.djangoproject.com/en/4.1/ref/contrib/admin/javascript/
 
-                        In this case we find the newly added row and initialize the
-                        dropzone on any dropzoneSelector on that row.
-                    */
-                    let rowIdx = parseInt(
-                        document.getElementById(
-                            'id_' + event.detail.formsetName + '-TOTAL_FORMS'
-                        ).value, 10
-                    ) - 1;
-                    let row_ = document.getElementById( event.detail.formsetName + '-' + rowIdx);
-                    var dropzones = $(row_).find(dropzoneSelector)
+        // Handle initialization of the dropzone on dynamic formsets (i.e. Django admin inlines)
+        $(document).on('formset:added', function (ev, row) {
+            if(ev.detail && ev.detail.formsetName) {
+                /*
+                    Django 4.1 changed the event type being fired when adding
+                    a new formset from a jQuery to a vanilla JavaScript event.
+                    https://docs.djangoproject.com/en/4.1/ref/contrib/admin/javascript/
 
-                } else {
-                    var dropzones = $(row).find(dropzoneSelector);
-                }
+                    In this case we find the newly added row and initialize the
+                    dropzone on any dropzoneSelector on that row.
+                */
+                let rowIdx = parseInt(
+                    document.getElementById(
+                        'id_' + event.detail.formsetName + '-TOTAL_FORMS'
+                    ).value, 10
+                ) - 1;
+                let row_ = document.getElementById(event.detail.formsetName + '-' + rowIdx);
+                var dropzones = $(row_).find(dropzoneSelector)
 
-                dropzones.each(createDropzone);
-            });
-        } else {
-            $('.add-row a').on('click', function () {
-                var dropzones = $(dropzoneSelector);
-                dropzones.each(createDropzone);
-            });
-        }
+            } else {
+                var dropzones = $(row).find(dropzoneSelector);
+            }
+
+            dropzones.each(createDropzone);
+        });
     }
 });

--- a/filer/static/filer/js/addons/dropzone.init.js
+++ b/filer/static/filer/js/addons/dropzone.init.js
@@ -164,7 +164,7 @@ djQuery(function ($) {
         // There is no way to feature detect the new behavior implemented in Django 1.9
         if (!window.__admin_utc_offset__) {
             $(document).on('formset:added', function (ev, row) {
-                if(ev.detail.formsetName) {
+                if(ev.detail && ev.detail.formsetName) {
                     /*
                         Django 4.1 changed the event type being fired when adding
                         a new formset from a jQuery to a vanilla JavaScript event.


### PR DESCRIPTION
## Description



Django 4.1 changed the JavaScript event type being fired when adding a new formset from a jQuery to a vanilla JavaScript event. https://docs.djangoproject.com/en/4.1/ref/contrib/admin/javascript/

This broke the drag-and-drop feature when adding dynamic inlines containing Filer fields in e.g. the Django admin, because the dropzone failed to initialize.

This patch checks for Django 4.1 and initializes the dropzone on newly added inline rows.

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

This fixes #1400.
## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
