### PR TITLE
fix: Added compatibility code in aldryn_config go support setting THUMBNAIL_DEFAULT_STORAGE in django 4.2

### DIFF
--- a/aldryn_config.py
+++ b/aldryn_config.py
@@ -47,7 +47,12 @@ class Form(forms.BaseForm):
         # If the DEFAULT_FILE_STORAGE has been set to a value known by
         # aldryn-django, then use that as THUMBNAIL_DEFAULT_STORAGE as well.
         for storage_backend in storage.SCHEMES.values():
-            if storage_backend == settings['DEFAULT_FILE_STORAGE']:
+            # Process before django 4.2
+            if storage_backend == settings.get('DEFAULT_FILE_STORAGE', None):
+                settings['THUMBNAIL_DEFAULT_STORAGE'] = storage_backend
+                break
+            # Process django 4.2 and after
+            if storage_backend == settings.get('STORAGES', {}).get('default', {}).get('BACKEND', None):
                 settings['THUMBNAIL_DEFAULT_STORAGE'] = storage_backend
                 break
         return settings


### PR DESCRIPTION

## Description
This change adds compatibility to django 4.2 and the new way storages and handled. 

## Related resources

https://docs.djangoproject.com/en/4.2/releases/4.2/#custom-file-storages

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
