### PR TITLE
fix: Compatibility with custom images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11' ]
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         requirements-file: [
           django-3.2.txt,
           django-4.0.txt,
@@ -16,6 +16,7 @@ jobs:
           django-4.2.txt,
           django-5.0.txt,
         ]
+        custom-image-model: [false, true]
         exclude:
           - requirements-file: django-5.0.txt
             python-version: 3.8
@@ -41,8 +42,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r tests/requirements/${{ matrix.requirements-file }}
         python setup.py install
+    - name: Enable the custom image model
+      run: echo "CUSTOM_IMAGE=custom_image.Image" >> $GITHUB_ENV
+      if: ${{ matrix.custom-image-model }}
     - name: Run coverage
       run: coverage run setup.py test
-
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -1,6 +1,7 @@
 import mimetypes
 
 from django import forms
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
 from django.contrib.admin.utils import unquote
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import Http404, HttpResponse, HttpResponseRedirect
@@ -19,8 +20,12 @@ from easy_thumbnails.options import ThumbnailOptions
 from .. import settings
 from ..models import BaseImage, File
 from ..settings import DEFERRED_THUMBNAIL_SIZES
+from ..utils.loader import load_model
 from .permissions import PrimitivePermissionAwareModelAdmin
 from .tools import AdminContext, admin_url_params_encoded, popup_status
+
+
+Image = load_model(settings.FILER_IMAGE_MODEL)
 
 
 class FileAdminChangeFrom(forms.ModelForm):
@@ -123,12 +128,18 @@ class FileAdmin(PrimitivePermissionAwareModelAdmin):
 
     def render_change_form(self, request, context, add=False, change=False,
                            form_url='', obj=None):
-        info = self.model._meta.app_label, self.model._meta.model_name
-        extra_context = {'show_delete': True,
-                         'history_url': 'admin:%s_%s_history' % info,
-                         'is_popup': popup_status(request),
-                         'filer_admin_context': AdminContext(request)}
-        context.update(extra_context)
+        context.update({
+            'show_delete': True,
+            'history_url': admin_urlname(self.opts, 'history'),
+            'expand_image_url': None,
+            'is_popup': popup_status(request),
+            'filer_admin_context': AdminContext(request),
+        })
+        if obj and obj.mime_maintype == 'image' and obj.file.exists():
+            if 'svg' in obj.mime_type:
+                context['expand_image_url'] = reverse(admin_urlname(Image._meta, 'expand'), args=(obj.pk,))
+            else:
+                context['expand_image_url'] = obj.file.url
         return super().render_change_form(
             request=request, context=context, add=add, change=change,
             form_url=form_url, obj=obj)

--- a/filer/admin/imageadmin.py
+++ b/filer/admin/imageadmin.py
@@ -91,7 +91,7 @@ class ImageAdmin(FileAdmin):
         return super().get_urls() + [
             path("expand/<int:file_id>",
                  self.admin_site.admin_view(self.expand_view),
-                 name=f"filer_{self.model._meta.model_name}_expand_view")
+                 name=f"{self.opts.app_label}_{self.opts.model_name}_expand")
         ]
 
     def expand_view(self, request, file_id):

--- a/filer/management/commands/filer_check.py
+++ b/filer/management/commands/filer_check.py
@@ -7,6 +7,7 @@ from django.utils.module_loading import import_string
 from PIL import UnidentifiedImageError
 
 from filer import settings as filer_settings
+from filer.utils.loader import load_model
 
 
 class Command(BaseCommand):
@@ -130,10 +131,9 @@ class Command(BaseCommand):
         import easy_thumbnails
         from easy_thumbnails.VIL import Image as VILImage
 
-        from filer.models.imagemodels import Image
         from filer.utils.compatibility import PILImage
 
-        no_dimensions = Image.objects.filter(
+        no_dimensions = load_model(filer_settings.FILER_IMAGE_MODEL).objects.filter(
             Q(_width=0) | Q(_width__isnull=True)
         )
         self.stdout.write(f"trying to set dimensions on {no_dimensions.count()} files")

--- a/filer/templates/admin/filer/tools/detail_info.html
+++ b/filer/templates/admin/filer/tools/detail_info.html
@@ -10,9 +10,8 @@
                         <span class="icon fa fa-download filer-icon filer-icon-download"></span>&nbsp;
                         <span>{% translate "Download" %}</span>
                     </a>
-                    {% if original.mime_maintype == 'image' %}
-                        <a href="{% if 'svg' in original.mime_type %}{% url 'admin:filer_image_expand_view' original.pk %}{% else %}{{ original.file.url }}{% endif %}"
-                           target="_blank" rel="noopener noreferrer" class="button">
+                    {% if expand_image_url %}
+                        <a href="{{ expand_image_url }}" target="_blank" rel="noopener noreferrer" class="button">
                             <span>{% translate "Expand" %}</span>&nbsp;
                             <span class="icon filer-icon filer-icon-expand fa fa-expand"></span>
                         </a>

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -7,3 +7,4 @@ django-app-helper>=3.3.1
 coverage
 isort
 flake8
+packaging

--- a/tests/test_filer_check.py
+++ b/tests/test_filer_check.py
@@ -9,8 +9,12 @@ from django.utils.module_loading import import_string
 
 from filer import settings as filer_settings
 from filer.models.filemodels import File
-from filer.models.imagemodels import Image
+from filer.settings import FILER_IMAGE_MODEL
+from filer.utils.loader import load_model
 from tests.helpers import create_image
+
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 
 class FilerCheckTestCase(TestCase):


### PR DESCRIPTION
## Description

Fixes the issue mentioned below. As suggested in that thread, I moved the generation of the expand link into the Python code, so that it gets passed to the template via context (which also moves logic from the template to the view layer, which should be a good thing).

While implementing the fix and testing via tox, I found that:
* the recent changes to the `filer_check` command were not compatible with a custom image model either
* while the tox tests have a flag to test with or without a swapped image model, the CI tests running via GitHub actions do not, meaning that there aren't any automated tests with a swapped image model right now

Therefore, I took the liberty to fix the mentioned command and extended the test action matrix with a flag for the image model swap (similar to the tox setup), so that problems with a custom image model have a chance to be caught automatically.

## Related resources

* #1450 

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
