### PR TITLE
method clean_subject_location not implemented correctly

### DIFF
--- a/filer/admin/imageadmin.py
+++ b/filer/admin/imageadmin.py
@@ -46,8 +46,7 @@ class ImageAdminForm(FileAdminChangeFrom):
         for subject location widget to receive valid coordinates on field
         validation errors.
         """
-        cleaned_data = super().clean()
-        subject_location = cleaned_data['subject_location']
+        subject_location = self.cleaned_data['subject_location']
         if not subject_location:
             # if supplied subject location is empty, do not check it
             return subject_location
@@ -69,7 +68,7 @@ class ImageAdminForm(FileAdminChangeFrom):
         else:
             return subject_location
 
-        self._set_previous_subject_location(cleaned_data)
+        self._set_previous_subject_location(self.cleaned_data)
         raise forms.ValidationError(
             string_concat(
                 err_msg,


### PR DESCRIPTION
## Description

Method `clean_subject_location` not implemented correctly.

According to the [Django docs](https://docs.djangoproject.com/en/5.0/ref/forms/validation/#cleaning-a-specific-field-attribute) and to my own experience, a method for cleaning a specific field attribute should not itself call `super().clean()`. This is because this method is invoked later anyway. In the current implementation the method `FileAdminChangeFrom.clean()` is called twice, which in my opinion should not happen.

It also sometimes causes problems if users try to replace an image using the Filer's admin image detail view.

Since no functionality changed, I did not add any extra test.

## Checklist

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
