### PR TITLE
fix: directory listing with svg image

### DIFF
--- a/filer/templates/admin/filer/folder/directory_table_list.html
+++ b/filer/templates/admin/filer/folder/directory_table_list.html
@@ -139,7 +139,7 @@
                             </td>
                             <td class="column-action">
                                 {% if file.canonical_url %}
-                                    <a href="{% if 'svg' in file.mime_type %}{% url 'admin:filer_image_expand_view' file.pk %}{% else %}{{ file.canonical_url }}{% endif %}"
+                                    <a href="{% if 'svg' in file.mime_type %}{% url 'admin:filer_image_expand' file.pk %}{% else %}{{ file.canonical_url }}{% endif %}"
                                        data-url="{{ file.canonical_url }}"
                                        data-msg="{% trans 'URL copied to clipboard' %}"
                                        rel="noopener noreferrer"


### PR DESCRIPTION
## Description

[fa385bd2b4b3022f54499bbb3c603d463f4baf2e](https://github.com/django-cms/django-filer/commit/fa385bd2b4b3022f54499bbb3c603d463f4baf2e) removed the `_view` suffix from url name

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
