### PR TITLE
feat: Accept new `STORAGES` setting, introduced in Django 4.2

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -69,7 +69,9 @@ e.g::
 
 Defaults to FileSystemStorage in ``<MEDIA_ROOT>/filer_public/`` and ``<MEDIA_ROOT>/filer_public_thumbnails/`` for public files and
 ``<MEDIA_ROOT>/../smedia/filer_private/`` and ``<MEDIA_ROOT>/../smedia/filer_private_thumbnails/`` for private files.
-Public storage uses ``DEFAULT_FILE_STORAGE`` as default storage backend.
+Public storage uses the default storage's backend. This is taken from Django's ``STORAGES``
+setting if it exists or, if not, from the ``DEFAULT_FILE_STORAGE`` setting for compatibility
+with earlier Django versions (5.0 or below).
 
 ``UPLOAD_TO`` is the function to generate the path relative to the storage root. The
 default generates a random path like ``1d/a5/1da50fee-5003-46a1-a191-b547125053a8/filename.jpg``. This

--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -192,7 +192,7 @@ class FileAdmin(PrimitivePermissionAwareModelAdmin):
     def display_canonical(self, instance):
         canonical = instance.canonical_url
         if canonical:
-            return mark_safe('<a href="{}">{}</a>'.format(canonical, canonical))
+            return mark_safe(f'<a href="{canonical}">{canonical}</a>')
         else:
             return '-'
     display_canonical.allow_tags = True

--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -253,10 +253,10 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
                 self.get_queryset(request).get(id=last_folder_id)
             except self.model.DoesNotExist:
                 url = reverse('admin:filer-directory_listing-root')
-                url = "{}{}".format(url, admin_url_params_encoded(request))
+                url = f"{url}{admin_url_params_encoded(request)}"
             else:
                 url = reverse('admin:filer-directory_listing', kwargs={'folder_id': last_folder_id})
-                url = "{}{}".format(url, admin_url_params_encoded(request))
+                url = f"{url}{admin_url_params_encoded(request)}"
             return HttpResponseRedirect(url)
         elif folder_id is None:
             folder = FolderRoot()
@@ -840,7 +840,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         else:
             # Don't display link to edit, because it either has no
             # admin or is edited inline.
-            return '{}: {}'.format(capfirst(opts.verbose_name), force_str(obj))
+            return f'{capfirst(opts.verbose_name)}: {force_str(obj)}'
 
     def _check_copy_perms(self, request, files_queryset, folders_queryset):
         try:
@@ -1073,7 +1073,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         count = itertools.count(1)
         original = name
         while destination.contains_folder(name):
-            name = "{}_{}".format(original, next(count))
+            name = f"{original}_{next(count)}"
         return name
 
     def _copy_folder(self, folder, destination, suffix, overwrite):

--- a/filer/fields/file.py
+++ b/filer/fields/file.py
@@ -60,7 +60,7 @@ class AdminFileWidget(ForeignKeyRawIdWidget):
         hidden_input = super(ForeignKeyRawIdWidget, self).render(name, value, attrs)  # grandparent super
         context = {
             'hidden_input': hidden_input,
-            'lookup_url': '{}{}'.format(related_url, lookup_url),
+            'lookup_url': f'{related_url}{lookup_url}',
             'change_url': change_url,
             'object': obj,
             'lookup_name': name,

--- a/filer/fields/folder.py
+++ b/filer/fields/folder.py
@@ -54,7 +54,7 @@ class AdminFolderWidget(ForeignKeyRawIdWidget):
         # API to determine the ID dynamically.
         context = {
             'hidden_input': hidden_input,
-            'lookup_url': '{}{}'.format(related_url, url),
+            'lookup_url': f'{related_url}{url}',
             'lookup_name': name,
             'span_id': css_id_description_txt,
             'object': obj,

--- a/filer/fields/multistorage_file.py
+++ b/filer/fields/multistorage_file.py
@@ -159,7 +159,7 @@ class MultiStorageFileField(easy_thumbnails_fields.ThumbnailerField):
             encoded_string = base64.b64encode(payload_file.read()).decode('utf-8')
             return value, encoded_string
         except OSError:
-            warnings.warn('The payload for "{}" is missing. No such file on disk: {}!'.format(obj.original_filename, self.storage.location))
+            warnings.warn(f'The payload for "{obj.original_filename}" is missing. No such file on disk: {self.storage.location}!')
             return value
 
     def to_python(self, value):

--- a/filer/models/clipboardmodels.py
+++ b/filer/models/clipboardmodels.py
@@ -35,7 +35,7 @@ class Clipboard(models.Model):
             return True
 
     def __str__(self):
-        return "Clipboard {} of {}".format(self.id, self.user)
+        return f"Clipboard {self.id} of {self.user}"
 
 
 class ClipboardItem(models.Model):

--- a/filer/models/filemodels.py
+++ b/filer/models/filemodels.py
@@ -158,9 +158,9 @@ class File(PolymorphicModel, mixins.IconsMixin):
 
     def __str__(self):
         if self.name in ('', None):
-            text = "{}".format(self.original_filename)
+            text = f"{self.original_filename}"
         else:
-            text = "{}".format(self.name)
+            text = f"{self.name}"
         return text
 
     @classmethod
@@ -312,7 +312,7 @@ class File(PolymorphicModel, mixins.IconsMixin):
             text = self.original_filename or 'unnamed file'
         else:
             text = self.name
-        text = "{}".format(text)
+        text = f"{text}"
         return text
 
     def __lt__(self, other):

--- a/filer/models/thumbnailoptionmodels.py
+++ b/filer/models/thumbnailoptionmodels.py
@@ -38,7 +38,7 @@ class ThumbnailOption(models.Model):
         verbose_name_plural = _("thumbnail options")
 
     def __str__(self):
-        return '{} -- {} x {}'.format(self.name, self.width, self.height)
+        return f'{self.name} -- {self.width} x {self.height}'
 
     @property
     def as_dict(self):

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -59,7 +59,10 @@ FILER_FILE_MODELS = getattr(
     settings, 'FILER_FILE_MODELS',
     (FILER_IMAGE_MODEL, 'filer.File'))
 
-DEFAULT_FILE_STORAGE = getattr(settings, 'DEFAULT_FILE_STORAGE', 'django.core.files.storage.FileSystemStorage')
+if hasattr(settings, "STORAGES") and 'default' in settings.STORAGES:
+    DEFAULT_FILE_STORAGE = settings.STORAGES['default'].get('BACKEND', 'django.core.files.storage.FileSystemStorage')
+else:
+    DEFAULT_FILE_STORAGE = getattr(settings, 'DEFAULT_FILE_STORAGE', 'django.core.files.storage.FileSystemStorage')
 
 MINIMAL_FILER_STORAGES = {
     'public': {

--- a/filer/templatetags/filer_tags.py
+++ b/filer/templatetags/filer_tags.py
@@ -89,7 +89,7 @@ def filesize(bytes, format='auto1024'):
             unit = '{}{}'.format(base == 1024 and unit.upper() or unit,
                              base == 1024 and 'iB' or 'B')
 
-        return '{} {}'.format(bytes, unit)
+        return f'{bytes} {unit}'
 
     if bytes == 0:
         return bytes

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -25,7 +25,7 @@ def create_folder_structure(depth=2, sibling=2, parent=None):
         depth_range.reverse()
         for d in depth_range:
             for s in range(1, sibling + 1):
-                name = "folder: %s -- %s" % (str(d), str(s))
+                name = "folder: {} -- {}".format(str(d), str(s))
                 folder = Folder(name=name, parent=parent)
                 folder.save()
                 create_folder_structure(depth=d - 1, sibling=sibling, parent=folder)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -629,7 +629,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
                 'admin:filer-ajax_upload',
                 kwargs={
                     'folder_id': folder.pk + 1}
-            ) + '?filename={0}'.format(self.image_name)
+            ) + f'?filename={self.image_name}'
             response = self.client.post(
                 url,
                 data=file_obj.read(),
@@ -693,7 +693,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
                 'admin:filer-ajax_upload',
                 kwargs={
                     'folder_id': folder.pk}
-            ) + '?filename={0}'.format(self.image_name)
+            ) + f'?filename={self.image_name}'
             response = self.client.post(
                 url,
                 data=file_obj.read(),
@@ -759,7 +759,7 @@ class FilerClipboardAdminUrlsTests(TestCase):
                     'admin:filer-ajax_upload',
                     kwargs={
                         'folder_id': folder.pk}
-                ) + '?filename={0}'.format(self.image_name)
+                ) + f'?filename={self.image_name}'
                 response = self.client.post(
                     url,
                     data=file_obj.read(),
@@ -1103,10 +1103,10 @@ class FilerBulkOperationsTests(BulkOperationsMixin, TestCase):
         'new_name' should be a plain string, no formatting supported.
         """
         if file_obj is not None:
-            checkbox_name = 'file-{}'.format(file_obj.id)
+            checkbox_name = f'file-{file_obj.id}'
             files = [file_obj]
         elif folder_obj is not None:
-            checkbox_name = 'folder-{}'.format(folder_obj.id)
+            checkbox_name = f'folder-{folder_obj.id}'
             # files inside this folder, non-recursive
             files = File.objects.filter(folder=folder_obj)
         else:
@@ -1322,9 +1322,9 @@ class FolderListingTest(TestCase):
             item_list = response.context['paginated_items'].object_list
             # user sees all items: FOO, BAR, BAZ, SAMP
             self.assertEqual(
-                set(folder.pk for folder in item_list),
-                set([self.foo_folder.pk, self.bar_folder.pk, self.baz_folder.pk,
-                     self.spam_file.pk]))
+                {folder.pk for folder in item_list},
+                {self.foo_folder.pk, self.bar_folder.pk, self.baz_folder.pk, self.spam_file.pk}
+            )
 
     def test_folder_ownership(self):
         with SettingsOverride(filer_settings, FILER_ENABLE_PERMISSIONS=True):
@@ -1336,8 +1336,8 @@ class FolderListingTest(TestCase):
             # he doesn't see BAR, BAZ and SPAM because he doesn't own them
             # and no permission has been given
             self.assertEqual(
-                set(folder.pk for folder in item_list),
-                set([self.foo_folder.pk]))
+                {folder.pk for folder in item_list},
+                {self.foo_folder.pk})
 
     def test_with_permission_given_to_folder(self):
         with SettingsOverride(filer_settings, FILER_ENABLE_PERMISSIONS=True):
@@ -1355,8 +1355,8 @@ class FolderListingTest(TestCase):
             item_list = response.context['paginated_items'].object_list
             # user sees 2 folder : FOO, BAR
             self.assertEqual(
-                set(folder.pk for folder in item_list),
-                set([self.foo_folder.pk, self.bar_folder.pk]))
+                {folder.pk for folder in item_list},
+                {self.foo_folder.pk, self.bar_folder.pk})
 
     def test_with_permission_given_to_parent_folder(self):
         with SettingsOverride(filer_settings, FILER_ENABLE_PERMISSIONS=True):
@@ -1373,9 +1373,9 @@ class FolderListingTest(TestCase):
             item_list = response.context['paginated_items'].object_list
             # user sees all items because he has permissions on the parent folder
             self.assertEqual(
-                set(folder.pk for folder in item_list),
-                set([self.foo_folder.pk, self.bar_folder.pk, self.baz_folder.pk,
-                     self.spam_file.pk]))
+                {folder.pk for folder in item_list},
+                {self.foo_folder.pk, self.bar_folder.pk, self.baz_folder.pk, self.spam_file.pk}
+            )
 
     def test_search_against_owner(self):
         url = reverse('admin:filer-directory_listing',
@@ -1416,7 +1416,7 @@ class FolderListingTest(TestCase):
 
         # Create a file with a problematic filename
         problematic_file = django.core.files.base.ContentFile('some data')
-        filename = u'christopher_eccleston'
+        filename = 'christopher_eccleston'
         problematic_file.name = filename
         self.spam_file = File.objects.create(
             owner=self.staff_user, original_filename=filename,

--- a/tests/test_form_fields.py
+++ b/tests/test_form_fields.py
@@ -24,5 +24,5 @@ class AdminFileWidgetTests(TestCase):
         content = widget.render("foo", file.id, {})
 
         self.assertIn(
-            "/admin/filer/file/{}/change/?_edit_from_widget=1".format(file.id), content
+            f"/admin/filer/file/{file.id}/change/?_edit_from_widget=1", content
         )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -27,4 +27,4 @@ class MigrationTestCase(TestCase):
             status_code = '0'
 
         if status_code == '1':
-            self.fail('There are missing migrations:\n {}'.format(output.getvalue()))
+            self.fail(f'There are missing migrations:\n {output.getvalue()}')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -87,19 +87,19 @@ class FilerApiTests(TestCase):
         self.assertEqual(len(icons), len(filer_settings.FILER_ADMIN_ICON_SIZES))
         for size in filer_settings.FILER_ADMIN_ICON_SIZES:
             self.assertEqual(os.path.basename(icons[size]),
-                             file_basename + '__%sx%s_q85_crop_subsampling-2_upscale.jpg' % (size, size))
+                             file_basename + '__{}x{}_q85_crop_subsampling-2_upscale.jpg'.format(size, size))
 
     def test_access_icons_property(self):
         """Test IconsMixin that calls static on a non-existent file"""
 
-        class CustomObj(IconsMixin, object):
+        class CustomObj(IconsMixin):
             _icon = 'custom'
 
         custom_obj = CustomObj()
         try:
             icons = custom_obj.icons
         except Exception as e:
-            self.fail("'.icons' access raised Exception {0} unexpectedly!".format(e))
+            self.fail(f"'.icons' access raised Exception {e} unexpectedly!")
         self.assertEqual(len(icons), len(filer_settings.FILER_ADMIN_ICON_SIZES))
 
     def test_file_upload_public_destination(self):


### PR DESCRIPTION
## Description

Fixes #1458.

Django 4.2 introduced the new [``STORAGES`` setting](https://docs.djangoproject.com/en/4.2/ref/settings/#storages). The historic ``DEFAULT_FILE_STORAGE`` setting is deprecated and will be removed in Django 5.1. 

This PR makes use of the ``STORAGES`` setting if present, otherwise falls back to ``DEFAULT_FILE_STORAGE`` for compatibility with older Django versions.

https://github.com/fsbraun/django-filer/blob/984a45b71654dc5e4b349b076a726aaa96988d86/filer/settings.py#L62-L65

Also, this PR includes the changes from `pyupgrade` for Python 3.8+

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #1458
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
