### PR TITLE
feat: Replace `render` with `TemplateResponse` in admin views

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -16,7 +16,8 @@ from django.db import models, router
 from django.db.models import Case, F, OuterRef, Subquery, When
 from django.db.models.functions import Coalesce, Lower
 from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
+from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.encoding import force_str
 from django.utils.html import escape, format_html
@@ -480,7 +481,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
             'enable_permissions': settings.FILER_ENABLE_PERMISSIONS,
             'can_make_folder': request.user.is_superuser or (folder.is_root and settings.FILER_ALLOW_REGULAR_USERS_TO_ADD_ROOT_FOLDERS) or permissions.get("has_add_children_permission"),
         })
-        return render(request, self.directory_listing_template, context)
+        return TemplateResponse(request, self.directory_listing_template, context)
 
     def filter_folder(self, qs, terms=()):
         # Source: https://github.com/django/django/blob/1.7.1/django/contrib/admin/options.py#L939-L947  flake8: noqa
@@ -814,7 +815,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         })
 
         # Display the destination folder selection page
-        return render(
+        return TemplateResponse(
             request,
             "admin/filer/delete_selected_files_confirmation.html",
             context
@@ -954,7 +955,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         })
 
         # Display the destination folder selection page
-        return render(request, "admin/filer/folder/choose_move_destination.html", context)
+        return TemplateResponse(request, "admin/filer/folder/choose_move_destination.html", context)
 
     move_files_and_folders.short_description = _("Move selected files and/or folders")
 
@@ -1037,7 +1038,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         })
 
         # Display the rename format selection page
-        return render(request, "admin/filer/folder/choose_rename_format.html", context)
+        return TemplateResponse(request, "admin/filer/folder/choose_rename_format.html", context)
 
     rename_files.short_description = _("Rename files")
 
@@ -1169,7 +1170,7 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         })
 
         # Display the destination folder selection page
-        return render(request, "admin/filer/folder/choose_copy_destination.html", context)
+        return TemplateResponse(request, "admin/filer/folder/choose_copy_destination.html", context)
 
     copy_files_and_folders.short_description = _("Copy selected files and/or folders")
 
@@ -1298,6 +1299,6 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         })
 
         # Display the resize options page
-        return render(request, "admin/filer/folder/choose_images_resize_options.html", context)
+        return TemplateResponse(request, "admin/filer/folder/choose_images_resize_options.html", context)
 
     resize_images.short_description = _("Resize selected images")

--- a/filer/admin/imageadmin.py
+++ b/filer/admin/imageadmin.py
@@ -1,5 +1,6 @@
 from django import forms
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
+from django.template.response import TemplateResponse
 from django.urls import path
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
@@ -95,9 +96,13 @@ class ImageAdmin(FileAdmin):
 
     def expand_view(self, request, file_id):
         image = get_object_or_404(self.model, pk=file_id)
-        return render(request, "admin/filer/image/expand.html", context={
-            "original_url": image.url
-        })
+        return TemplateResponse(
+            request,
+            "admin/filer/image/expand.html",
+            context={
+                "original_url": image.url
+            },
+        )
 
 
 if FILER_IMAGE_MODEL == 'filer.Image':

--- a/filer/admin/views.py
+++ b/filer/admin/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.http.response import HttpResponseBadRequest
-from django.shortcuts import render
+from django.template.response import TemplateResponse
 from django.utils.translation import gettext_lazy as _
 
 from .. import settings as filer_settings
@@ -58,7 +58,7 @@ def make_folder(request, folder_id=None):
                 new_folder.parent = folder
                 new_folder.owner = request.user
                 new_folder.save()
-                return render(request, 'admin/filer/dismiss_popup.html', context)
+                return TemplateResponse(request, 'admin/filer/dismiss_popup.html', context)
     else:
         new_folder_form = NewFolderForm()
 
@@ -69,7 +69,7 @@ def make_folder(request, folder_id=None):
         'is_popup': popup_status(request),
         'filer_admin_context': AdminContext(request),
     })
-    return render(request, 'admin/filer/folder/new_folder_form.html', context)
+    return TemplateResponse(request, 'admin/filer/folder/new_folder_form.html', context)
 
 
 @login_required


### PR DESCRIPTION
## Description

As requested in #1448 and common practice in the Django admin, this PR makes the admin views return a `TemplateResponse`. 

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #1448
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
