### PR TITLE
revert type hint to `typing.List`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: [3.8, 3.9, '3.10', '3.11', '3.12']
         requirements-file: [
           django-4.2.txt,
           django-5.0.txt,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,15 @@ jobs:
         os: [
           ubuntu-20.04,
         ]
+        exclude:
+          - requirements-file: django-5.0.txt
+            python-version: 3.8
+          - requirements-file: django-5.0.txt
+            python-version: 3.9
+          - requirements-file: django-main.txt
+            python-version: 3.8
+          - requirements-file: django-main.txt
+            python-version: 3.9
 
     steps:
     - uses: actions/checkout@v1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 CHANGELOG
 =========
 
+3.2.1 (2024-09-05)
+==================
+
+* fix: Restore python 3.8 and python 3.9 compatibility
+
 3.2.0 (2024-08-23)
 ==================
 

--- a/filer/__init__.py
+++ b/filer/__init__.py
@@ -13,4 +13,4 @@ Release logic:
  8. Publish the release and it will automatically release to pypi
 """
 
-__version__ = '3.2.0'
+__version__ = '3.2.1'

--- a/filer/cache.py
+++ b/filer/cache.py
@@ -65,7 +65,7 @@ def clear_folder_permission_cache(user: User, permission: typing.Optional[str] =
         cache.delete(get_folder_perm_cache_key(user, permission))
 
 
-def update_folder_permission_cache(user: User, permission: str, id_list: list[int]) -> None:
+def update_folder_permission_cache(user: User, permission: str, id_list: typing.List[int]) -> None:
     """
     Updates the cached folder permissions for a given user and permission.
 


### PR DESCRIPTION
## Description

avoid using type hints that drop support of python 3.8 and 3.9

## Related resources

* https://github.com/django-cms/django-filer/issues/1492
## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
