### PR TITLE
fix: remove extra brace in generated HTML of data-max-filesize attribute

### DIFF
--- a/filer/templates/admin/filer/folder/directory_listing.html
+++ b/filer/templates/admin/filer/folder/directory_listing.html
@@ -213,7 +213,7 @@
                                        data-url="{% url 'admin:filer-ajax_upload' folder_id=folder.id %}"
                                        data-max-uploader-connections="{{ uploader_connections }}"
                                        data-max-files="{{ max_files|safe }}"
-                                       {% if max_filesize %}}data-max-filesize="{{ max_filesize|safe }}"{% endif %}
+                                       {% if max_filesize %}data-max-filesize="{{ max_filesize|safe }}"{% endif %}
                                     >
                                         {% trans "Upload Files" %}
                                     </a>
@@ -223,7 +223,7 @@
                                        data-url="{% url 'admin:filer-ajax_upload' %}"
                                        data-max-uploader-connections="{{ uploader_connections }}"
                                        data-max-files="{{ max_files|safe }}"
-                                       {% if max_filesize %}}data-max-filesize="{{ max_filesize|safe }}"{% endif %}
+                                       {% if max_filesize %}data-max-filesize="{{ max_filesize|safe }}"{% endif %}
                                     >
                                         {% trans "Upload Files" %}
                                     </a>

--- a/filer/templates/admin/filer/folder/directory_table_list.html
+++ b/filer/templates/admin/filer/folder/directory_table_list.html
@@ -4,7 +4,7 @@
     <table class="js-filer-dropzone js-filer-dropzone-base navigator-table" id="result_list" data-url="{% if folder.id %}{% url 'admin:filer-ajax_upload' folder_id=folder.id %}{% else %}{% url 'admin:filer-ajax_upload' %}{% endif %}" data-folder-name="{% if folder.is_root %}{% translate 'Unsorted Uploads' %}{% else %}{{ folder.name }}{% endif %}"
            data-max-uploader-connections="{{ uploader_connections }}"
            data-max-files="{{ max_files|safe }}"
-           {% if max_filesize %}}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
+           {% if max_filesize %}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
         <thead>
             <tr>
                 <th class="column-checkbox">
@@ -170,7 +170,7 @@
          data-folder-name="{% if folder.is_root %}{% trans 'Unsorted Uploads' %}{% else %}{{ folder.name }}{% endif %}"
          data-max-uploader-connections="{{ uploader_connections }}"
          data-max-files="{{ max_files|safe }}"
-         {% if max_filesize %}}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
+         {% if max_filesize %}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
 
         <div class="icon"><span class="filer-icon filer-upload fa fa-cloud-upload"></span></div>
 

--- a/filer/templates/admin/filer/folder/directory_thumbnail_list.html
+++ b/filer/templates/admin/filer/folder/directory_thumbnail_list.html
@@ -4,7 +4,7 @@
 
     <div class="js-filer-dropzone js-filer-dropzone-base navigator-list" id="result_list" data-url="{% if folder.id %}{% url 'admin:filer-ajax_upload' folder_id=folder.id %}{% else %}{% url 'admin:filer-ajax_upload' %}{% endif %}" data-folder-name="{% if folder.is_root %}{% translate 'Unsorted Uploads' %}{% else %}{{ folder.name }}{% endif %}" data-max-uploader-connections="{{ uploader_connections }}"
          data-max-files="{{ max_files|safe }}"
-         {% if max_filesize %}}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
+         {% if max_filesize %}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
 
         <input type="checkbox" id="all-items-action-toggle">
 
@@ -43,7 +43,7 @@
                      data-folder-name="{{ subfolder.name }}"
                      data-max-uploader-connections="{{ uploader_connections }}"
                      data-max-files="{{ max_files|safe }}"
-                     {% if max_filesize %}}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
+                     {% if max_filesize %}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
 
                     <div class="navigator-checkbox">
                         {% if filer_admin_context.pick_folder and item.file_type == 'Folder' %}
@@ -146,7 +146,7 @@
        data-folder-name="{% if folder.is_root %}{% trans 'Unsorted Uploads' %}{% else %}{{ folder.name }}{% endif %}"
        data-max-uploader-connections="{{ uploader_connections }}"
        data-max-files="{{ max_files|safe }}"
-       {% if max_filesize %}}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
+       {% if max_filesize %}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
   <div class="icon"><span class="filer-icon filer-icon-upload fa fa-cloud-upload"></span></div>
 
       <div class="filer-dropzone-upload-welcome js-filer-dropzone-upload-welcome">

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -17,7 +17,7 @@
     <div class="js-filer-dropzone filer-dropzone{% if object %} js-object-attached{% endif %}"
          data-url="{% url 'admin:filer-ajax_upload' %}"
          data-max-files="1"
-         {% if max_filesize %}}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
+         {% if max_filesize %}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
         <div class="z-index-fix"></div>
         <div class="dz-default dz-message js-filer-dropzone-message{% if object %} hidden{% endif %}">
             <span class="icon filer-icon filer-icon-arrow-down fa fa-arrow-down"></span><span>{% translate "or drop your file here" %}</span>


### PR DESCRIPTION
## Description
Template insert an extra brace before `data-max-filesize` attribute making it not read as expected by table-dropzone.js


* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
