### PR TITLE
fix: uploadButton data-max-filesize attribute is not passed to file-uploader

### DIFF
--- a/filer/static/filer/js/addons/upload-button.js
+++ b/filer/static/filer/js/addons/upload-button.js
@@ -29,6 +29,7 @@ if (django.jQuery) {
         var infoMessage = $('.js-filer-dropzone-info-message');
         var hiddenClass = 'hidden';
         var maxUploaderConnections = uploadButton.data('max-uploader-connections') || 3;
+        var maxFilesize = parseInt(uploadButton.data('max-filesize') || 0, 10) * 1048576;
         var hasErrors = false;
         var updateUploadNumber = function () {
             uploadNumber.text(maxSubmitNum - submitNum + '/' + maxSubmitNum);
@@ -59,6 +60,7 @@ if (django.jQuery) {
             action: uploadUrl,
             button: uploadButton[0],
             maxConnections: maxUploaderConnections,
+            sizeLimit: maxFilesize,
             onSubmit: function (id) {
                 Cl.mediator.remove('filer-upload-in-progress', removeButton);
                 Cl.mediator.publish('filer-upload-in-progress');


### PR DESCRIPTION
The attribute exists on the upload button, but it is not read and used.

This PR fix `upload-button.js` to read the value tranform from MiB to bytes and pass the param to FileUploaderBasic object.


By the way, the library used is more than 10 years old of age (2011 ?)  and is not even maintained since 2018 (repo archived)
Also it is strange to have 2 distinct upload mechanisms, one for dropdown and one for upload button.


* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
