### PR TITLE
fix: incompatibility with djangocms-versioning-filer 1.3 was fixed

### DIFF
--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -35,7 +35,8 @@ class FileAdminChangeFrom(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["file"].widget = forms.FileInput()
+        if "file" in self.fields:
+            self.fields["file"].widget = forms.FileInput()
 
     def clean(self):
         from ..validation import validate_upload


### PR DESCRIPTION
When used with djangocms-versioning-filer, the `FileAdminChangeForm` might not have a file field due to missing permissions.
Since djangocms-versioning-filer 1.3 the constructor of `FileAdminChangeForm` crashes when opening the change URL of a published image.

This patch fixes this issue by adding a check whether the file field is present before overriding it.

## Description

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix compatibility issue with djangocms-versioning-filer 1.3 by ensuring the FileAdminChangeForm does not crash when the file field is missing due to permissions.

Bug Fixes:
- Fix crash in FileAdminChangeForm constructor when used with djangocms-versioning-filer 1.3 by checking for the presence of the file field before overriding it.

Tests:
- Modify tests to accommodate the logic change in FileAdminChangeForm.