### PR TITLE
fix: editing buttons missing in admin when file present

### DIFF
--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -14,7 +14,7 @@
         </span>
     </div>
 
-    <div class="js-filer-dropzone filer-dropzone{% if object %} js-object-attached{% endif %}"
+    <div class="js-filer-dropzone filer-dropzone{% if object %} js-object-attached{% endif %} "
          data-url="{% url 'admin:filer-ajax_upload' %}"
          data-max-files="1"
          {% if max_filesize %}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>
@@ -26,7 +26,7 @@
         <span class="filerFile js-file-selector">
             {% if object %}
                 {% if object.file.exists %}
-                    <a href="{{ object.url }}" target="_blank">{% file_icon object detail=True %}</a>
+                    <a href="{{ object.url }}" target="_blank">{% file_icon object detail="thumbnail" %}</a>
                     &nbsp;<span class="description_text">{{ object.label }}</span>
                 {% else %}
                     {% file_icon object %}

--- a/filer/templates/admin/filer/widgets/admin_file.html
+++ b/filer/templates/admin/filer/widgets/admin_file.html
@@ -14,7 +14,7 @@
         </span>
     </div>
 
-    <div class="js-filer-dropzone filer-dropzone{% if object %} js-object-attached{% endif %} "
+    <div class="js-filer-dropzone filer-dropzone{% if object %} js-object-attached{% endif %}"
          data-url="{% url 'admin:filer-ajax_upload' %}"
          data-max-files="1"
          {% if max_filesize %}data-max-filesize="{{ max_filesize|safe }}"{% endif %}>


### PR DESCRIPTION
## Description

This PR adds the `image-preview-container` to the admin file preview. This is needed so that the sass-rules from [`_image-info.scss`](https://github.com/django-cms/django-filer/blob/deafdc29f785010e31373b87c0bc828c83fb40eb/filer/private/sass/components/_image-info.scss#L165) gets applied. This fixes the issue described in #1499

<!--
If this is a security issue stop right here and follow our documentation:
http://docs.django-cms.org/en/latest/contributing/development-policies.html#reporting-security-issues
-->

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

I did not do the last item, as the slack-channel no longer exists :)

## Summary by Sourcery

Bug Fixes:
- Fix the missing editing buttons in the admin interface when a file is present by adding the 'image-preview-container' class.