### PR TITLE
fix: Avoid locale-dependent ratio

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   gulp:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version: [16.20.x]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -30,7 +30,7 @@ docutils==0.17.1
     # via
     #   restructuredtext-lint
     #   sphinx
-furo==2021.6.24b37
+furo==2025.7.19
     # via -r requirements.in
 idna==3.3
     # via requests

--- a/filer/templatetags/filer_admin_tags.py
+++ b/filer/templatetags/filer_admin_tags.py
@@ -190,7 +190,7 @@ def get_aspect_ratio_and_download_url(context, detail, file, height, width):
             # because they don't really have width or height
             if file.width:
                 width, height = 210, ceil(210 / file.width * file.height)
-                context['sidebar_image_ratio'] = file.width / 210
+                context['sidebar_image_ratio'] = '%.6F' % (file.width / 210)
     return height, width, context
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1935,6 +1935,22 @@ class FileIconContextTests(TestCase):
         self.assertNotIn('sidebar_image_ratio', context.keys())
         self.assertIn('download_url', context.keys())
 
+    def test_sidebar_image_ratio_format(self):
+        """
+        Test that sidebar_image_ratio is formatted as a string with 6 decimal places
+        to ensure consistent formatting regardless of locale settings
+        """
+        image = Image.objects.create(name='test.jpg')
+        image._width = 100
+        image._height = 200
+        image.save()
+        context = {}
+        height, width, context = get_aspect_ratio_and_download_url(context=context, detail=True, file=image, height=40, width=40)
+        self.assertIsInstance(context['sidebar_image_ratio'], str)
+        expected_ratio = '%.6F' % (image.width / 210)
+        self.assertEqual(context['sidebar_image_ratio'], expected_ratio)
+        self.assertEqual(context['sidebar_image_ratio'], '0.476190')
+
 
 class AdditionalAdminFormsTests(TestCase):
     def setUp(self):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1947,7 +1947,7 @@ class FileIconContextTests(TestCase):
         context = {}
         height, width, context = get_aspect_ratio_and_download_url(context=context, detail=True, file=image, height=40, width=40)
         self.assertIsInstance(context['sidebar_image_ratio'], str)
-        expected_ratio = '%.6F' % (image.width / 210)
+        expected_ratio = '%.6f' % (image.width / 210)
         self.assertEqual(context['sidebar_image_ratio'], expected_ratio)
         self.assertEqual(context['sidebar_image_ratio'], '0.476190')
 


### PR DESCRIPTION
## Description

This PR fixes a localization-related bug that affected both the admin UI and the data saved for images.

- After uploading an image, the focal-point marker in the admin looked "apparently" correctly centered.
- However, the cropping result in the frontend was wrongly offset, because the underlying `subject_location` saved was incorrect (e.g. 420,420 instead of the true center 500,500 for a 1000×1000 image).
- If you tried to "fix" it by setting `subject_location` manually to the correct center, the marker in the admin then appeared offset, while in the template the image was corretly cropped. 

Fix

Format `sidebar_image_ratio` as a dot-decimal string with 6 places using `%.6F` before it reaches the template:
```python
context['sidebar_image_ratio'] = '%.6F' % (file.width / 210)
```

This prevents localization from altering the value and keeps JS math consistent.
The change also aligns with `ImageAdminForm.sidebar_image_ratio()` which already returns a dot-decimal string for exactly this reason.

> Note: The 210 sidebar width is also defined as SIDEBAR_IMAGE_WIDTH.
> For consistency, it might make sense to reuse that constant in a follow-up refactor, but I’ve kept the scope of this PR minimal to fix the localization bug only.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix localization-related float formatting by casting sidebar_image_ratio to a consistent dot-decimal string, ensuring accurate image cropping

Bug Fixes:
- Prevent locale-dependent decimal separators from corrupting JS math and causing incorrect image focal-point offsets

Enhancements:
- Format sidebar_image_ratio as a six-decimal dot-formatted string in the template tag to match ImageAdminForm behavior