### PR TITLE
fix: Folder permission cache update sometimes raised TypeError

### DIFF
--- a/filer/cache.py
+++ b/filer/cache.py
@@ -86,4 +86,4 @@ def update_folder_permission_cache(user: UserModel, permission: str, id_list: ty
     permission (str): The permission to update.
     id_list (list): The list of IDs to set as the new permissions.
     """
-    cache.set(get_folder_perm_cache_key(user, permission), {user.pk: set(id_list)})
+    cache.set(get_folder_perm_cache_key(user, permission), {user.pk: id_list})

--- a/filer/cache.py
+++ b/filer/cache.py
@@ -86,6 +86,4 @@ def update_folder_permission_cache(user: UserModel, permission: str, id_list: ty
     permission (str): The permission to update.
     id_list (list): The list of IDs to set as the new permissions.
     """
-    perms = get_folder_permission_cache(user, permission) or {}
-    perms[user.pk] = id_list
-    cache.set(get_folder_perm_cache_key(user, permission), perms)
+    cache.set(get_folder_perm_cache_key(user, permission), {user.pk: set(id_list)})

--- a/tests/test_permission_cache.py
+++ b/tests/test_permission_cache.py
@@ -45,3 +45,9 @@ class PermissionCacheTests(TestCase):
         update_folder_permission_cache(self.user, self.permission, self.id_list)
         permissions = get_folder_permission_cache(self.user, self.permission)
         self.assertEqual(permissions, self.id_list)
+
+    def test_update_folder_permission_cache_overwrites_existing_cache_value(self):
+        update_folder_permission_cache(self.user, self.permission, {2})
+        update_folder_permission_cache(self.user, self.permission, self.id_list)
+        permissions = get_folder_permission_cache(self.user, self.permission)
+        self.assertEqual(permissions, self.id_list)


### PR DESCRIPTION
## Description

This PR fixes #1537. Thanks to @PeterW-LWL for catching this and providing a regression test!

@PeterW-LWL Do you want to give it a test run?

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Fix folder permission cache updating logic to store permissions as a set and overwrite stale cache values, preventing the observed TypeError.

Bug Fixes:
- Fix update_folder_permission_cache to always overwrite the cache with a set to prevent TypeError

Tests:
- Add regression test to verify that update_folder_permission_cache overwrites existing cache entries