### PR TITLE
Fix manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include README.rst
+recursive-include filer *.py
 recursive-include filer/locale *
 recursive-include filer/static *
 recursive-include filer/templates *


### PR DESCRIPTION
## Description

This fixes an installation problem, when installing directly from GitHub.
Then the Python files in folders `admin`, `contrib`, `fields`, etc are missing.

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Build:
- Update MANIFEST.in to include Python files from admin, contrib, fields, and other subpackages when installing from GitHub