### PR TITLE
fix: Failed to install submodules of filer

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,0 @@
-include LICENSE
-include README.rst
-recursive-include filer/locale *
-recursive-include filer/static *
-recursive-include filer/templates *
-recursive-exclude * *.py[co]
-recursive-exclude tests *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,12 @@ heif = ["pillow-heif"]
 Homepage = "https://github.com/django-cms/django-filer"
 
 [tool.setuptools]
-packages = ["filer", "filer.*"]
 include-package-data = true
 zip-safe = false
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["filer*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "filer.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,3 +114,7 @@ sections = [
 known_first_party = ["filer"]
 known_cms = ["cms", "menus"]
 known_django = ["django"]
+
+[tool.ruff]
+src = ["filer"]
+exclude = ["*/migrations/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ zip-safe = false
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["filer*"]
+include = ["filer*", "LICENSE"]
 
 [tool.setuptools.dynamic]
 version = {attr = "filer.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ heif = ["pillow-heif"]
 Homepage = "https://github.com/django-cms/django-filer"
 
 [tool.setuptools]
-packages = ["filer"]
+packages = ["filer", "filer.*"]
 include-package-data = true
 zip-safe = false
 


### PR DESCRIPTION
## Description

Replacement for #1543:

* Remove manifest
* Use find package in pyproject.toml instead of single constant

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Use dynamic package discovery in pyproject.toml and remove the obsolete manifest file

Enhancements:
- Replace static packages list with setuptools.find for package discovery

Chores:
- Remove MANIFEST.in file