### PR TITLE
fix: preserve "limit search to folder" state in pagination links #1553

### DIFF
--- a/filer/templates/admin/filer/folder/directory_table_list.html
+++ b/filer/templates/admin/filer/folder/directory_table_list.html
@@ -211,7 +211,7 @@
 
     <div class="nav-pages paginator">
         {% if paginated_items.has_previous %}
-            <a href="?page={{ paginated_items.previous_page_number }}{% if q %}&amp;q={{ q }}{% endif %}{% if request.GET.limit_search_to_folder %}&amp;limit_search_to_folder=on{% endif %}{% filer_admin_context_url_params '&' %}">
+            <a href="?page={{ paginated_items.previous_page_number }}{% if q %}&amp;q={{ q|urlencode }}{% endif %}{% if request.GET.limit_search_to_folder %}&amp;limit_search_to_folder=on{% endif %}{% filer_admin_context_url_params '&' %}">
                 {% trans "previous" %}
             </a>
         {% endif %}
@@ -221,7 +221,7 @@
         </span>
 
         {% if paginated_items.has_next %}
-            <a href="?page={{ paginated_items.next_page_number }}{% if q %}&amp;q={{ q }}{% endif %}{% if request.GET.limit_search_to_folder %}&amp;limit_search_to_folder=on{% endif %}{% filer_admin_context_url_params '&' %}">
+            <a href="?page={{ paginated_items.next_page_number }}{% if q %}&amp;q={{ q|urlencode }}{% endif %}{% if request.GET.limit_search_to_folder %}&amp;limit_search_to_folder=on{% endif %}{% filer_admin_context_url_params '&' %}">
                 {% trans "next" %}
             </a>
         {% endif %}

--- a/filer/templates/admin/filer/folder/directory_thumbnail_list.html
+++ b/filer/templates/admin/filer/folder/directory_thumbnail_list.html
@@ -186,7 +186,7 @@
 
     <div class="nav-pages paginator">
         {% if paginated_items.has_previous %}
-            <a href="?page={{ paginated_items.previous_page_number }}{% if q %}&amp;q={{ q }}{% endif %}{% if request.GET.limit_search_to_folder %}&amp;limit_search_to_folder=on{% endif %}{% filer_admin_context_url_params '&' %}">
+            <a href="?page={{ paginated_items.previous_page_number }}{% if q %}&amp;q={{ q|urlencode }}{% endif %}{% if request.GET.limit_search_to_folder %}&amp;limit_search_to_folder=on{% endif %}{% filer_admin_context_url_params '&' %}">
                 {% trans "previous" %}
             </a>
         {% endif %}
@@ -196,7 +196,7 @@
         </span>
 
         {% if paginated_items.has_next %}
-            <a href="?page={{ paginated_items.next_page_number }}{% if q %}&amp;q={{ q }}{% endif %}{% if request.GET.limit_search_to_folder %}&amp;limit_search_to_folder=on{% endif %}{% filer_admin_context_url_params '&' %}">
+            <a href="?page={{ paginated_items.next_page_number }}{% if q %}&amp;q={{ q|urlencode }}{% endif %}{% if request.GET.limit_search_to_folder %}&amp;limit_search_to_folder=on{% endif %}{% filer_admin_context_url_params '&' %}">
                 {% trans "next" %}
             </a>
         {% endif %}


### PR DESCRIPTION
## Description

Small fix, kind of hacky, pagination is duplicated and the GET vars propably should not checked like this. As mentioned in the original issue/report, there could be more elegant solution, but I'll let the filer team decide hwo to tackle this...

Fixes #1553 

## Checklist

* [X] I have opened this pull request against ``master``
* [x] There were none for pagination functionality...I have added or modified the tests when changing logic
* [X] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [X] Slack???  ;)I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Bug Fixes:
- Include the limit_search_to_folder flag in previous/next page URLs for both table and thumbnail directory views