### PR TITLE
fix django-app-helper link in the docs

### DIFF
--- a/docs/running_tests.rst
+++ b/docs/running_tests.rst
@@ -22,7 +22,7 @@ done for you. Tox will setup multiple virtual environments with different python
     tox -e py27-dj18 -- test filer.tests.models.FilerApiTests.test_create_folder_structure
 
 Other test runner options are also supported, see
-`django-app-helper <https://django-app-helper.readthedocs.io/en/develop/>`_
+`django-app-helper <https://django-app-helper.readthedocs.io/en/latest/>`_
 documentation for details.
 
 To speed things up a bit use `detox <http://pypi.python.org/pypi/detox/>`_. ``detox`` runs each testsuite in a


### PR DESCRIPTION
## Description

Very simple documentation link update. The link for django-app-helper on the [tests page](https://django-filer.readthedocs.io/en/latest/running_tests.html) is stale.

## Related resources

N/A

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
