### PR TITLE
chore: Update RTD build OS to latest

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
     python: "3.13"
     # You can also specify other tool versions:


### PR DESCRIPTION
## Description

Had an email about this;

> We are announcing the deprecation of the Ubuntu 20.04 LTS build image (build.os: ubuntu-20.04) on Read the Docs. After June 1, 2026, projects still using this image will fail when building until they are updated to a supported Ubuntu image.
>
> This change keeps our build images current and helps us prepare for Ubuntu 26.04 LTS support. Ubuntu 20.04 LTS is now an older base image and is [no longer receiving security updates](https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare), so we consider it insecure to continue to offer.
What do I need to do?
>
> Update your .readthedocs.yaml to use a newer supported image. For most projects, we recommend:
>
> ```
> build:
>   os: ubuntu-24.04
> ```
> Read the Docs currently supports ubuntu-22.04, ubuntu-24.04, and ubuntu-lts-latest for build.os. See all options in the docs: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Build:
- Switch Read the Docs build OS from ubuntu-20.04 to ubuntu-lts-latest in .readthedocs.yaml.