### PR TITLE
feat: By-default fast svg sanitation (deprecating svg validation)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -156,7 +156,7 @@ CHANGELOG
 * feat: Canonical URL action button now copies canonical URL to the user's
   clipboard
 * fix: Run validators on updated files in file change view
-* fix: Update mime type if uploading file in file change view
+* fix: Update MIME type if uploading file in file change view
 * fix: Do not allow to remove the file field from an uplaoded file in
   the admin interface
 * fix: refactor upload checks into running validators in the admin
@@ -344,7 +344,7 @@ CHANGELOG
 ==================
 
 * Fix #1214: `serve()` missing 1 required positional argument: `filer_file`.
-* Fix #1211: On upload MIME-type is not set correctly.
+* Fix #1211: On upload MIME type is not set correctly.
 
 
 2.0.1 (2020-09-04)

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -24,24 +24,24 @@ Mime type white list
 --------------------
 
 The first thing you can do to set up a security policy is to only allow
-white-listed mime types for upload.
+white-listed MIME types for upload.
 
 The setting ``FILER_MIME_TYPE_WHITELIST`` (default: ``[]``)  is a list of
 strings django-filer will consider for upload, e.g.::
 
     FILER_MIME_TYPE_WHITELIST = [
-        "text/plain",  # Exact mime type match
+        "text/plain",  # Exact MIME type match
         "image/*",  # All types of "image"
     ]
 
-If ``FILER_MIME_TYPE_WHITELIST`` is empty, all mime types will be accepted
+If ``FILER_MIME_TYPE_WHITELIST`` is empty, all MIME types will be accepted
 (default behaviour).
 
 .. note::
 
-    django-filer determines the mime-type of a file by its extension.
+    django-filer determines the MIME type of a file by its extension.
     It does **not** check if the file format is aligned with its extension.
-    Restricting mime types therefore effectively blocks certain extensions.
+    Restricting MIME types therefore effectively blocks certain extensions.
     It does not prevent a user from uploading an .exe file disguised as
     an image file, say .jpeg.
 
@@ -49,8 +49,8 @@ If ``FILER_MIME_TYPE_WHITELIST`` is empty, all mime types will be accepted
 Validation hooks
 ----------------
 
-Uploaded files are validated by their mime-type. The two bundled validators
-reject any ``text/html`` file and sanitize files with the mime type
+Uploaded files are validated by their MIME type. The two bundled validators
+reject any ``text/html`` file and sanitize files with the MIME type
 ``image/svg+xml``. Both HTML and SVG files are dangerous since they are
 executed by a browser without any warnings.
 
@@ -60,7 +60,7 @@ by the browser but still present a point of attack, if a user saves them
 to disk and executes them locally.**
 
 You can release validation restrictions by setting
-``FILER_REMOVE_FILE_VALIDATORS`` to a list of mime types to be removed from
+``FILER_REMOVE_FILE_VALIDATORS`` to a list of MIME types to be removed from
 validation. This is applicable to the two current validators for ``text/html``
 and ``image/svg+xml``, but also to any validators that might be added by
 default in future versions.
@@ -96,7 +96,7 @@ The two built-in validators are extremely simple.
         )
 
 This just rejects any file for upload. By default this happens for HTML files
-(mime type `text/html``).
+(MIME type `text/html``).
 
 The second built-in validator, ``filer.validation.sanitize_svg``, parses
 uploaded SVG files and rewrites them with any scripts, event handlers and
@@ -191,10 +191,10 @@ This approach is prone to false positives, since those byte sequences can
 legitimately appear inside SVG text content. ``sanitize_svg`` (the
 default) is usually the better choice.
 
-Block other mime-types
+Block other MIME types
 ----------------------
 
-To block other mime types add an entry for that mime type to
+To block other MIME types add an entry for that MIME type to
 ``FILER_ADD_FILE_VALIDATORS`` with ``filer.validation.deny``::
 
     FILER_ADD_FILE_VALIDATORS[mime_type] = ["filer.validation.deny"]
@@ -244,8 +244,8 @@ time.
 The ``owner`` argument is the ``User`` object of the user uploading the file.
 You can use it to distinguish validation for certain user groups if needed.
 
-If you distinguish validation by the mime type, remember to register the
-validator function for all relevant mime types.
+If you distinguish validation by the MIME type, remember to register the
+validator function for all relevant MIME types.
 
 
 .. _check_virus:
@@ -267,7 +267,7 @@ you can add a validator that checks for viruses in uploaded files.
 .. code-block:: python
 
     def validate_octet_stream(file_name: str, file: typing.IO, owner: User, mime_type: str) -> None:
-        """Octet streams are binary files without a specific mime type. They are run through
+        """Octet streams are binary files without a specific MIME type. They are run through
         a virus check."""
         try:
             from django_clamd.validators import validate_file_infection

--- a/docs/validation.rst
+++ b/docs/validation.rst
@@ -11,8 +11,9 @@ corrupted file which could cause harm to other staff users or
 even visitors of the website.
 
 To this end django-filer implements a basic file validation
-framework. By default, it will reject any HTML files for upload and certain
-SVG files that might include JavaScript code.
+framework. By default, it will reject any HTML files for upload and
+sanitize uploaded SVG files, stripping any scripts, event handlers or
+other non-graphic content.
 
 .. warning::
 
@@ -49,9 +50,9 @@ Validation hooks
 ----------------
 
 Uploaded files are validated by their mime-type. The two bundled validators
-reject and ``text/html`` file and will check for signs of JavaScript code in
-files with the mime type ``image/svg+xml``. Those files are dangerous since
-they are executed by a browser without any warnings.
+reject any ``text/html`` file and sanitize files with the mime type
+``image/svg+xml``. Both HTML and SVG files are dangerous since they are
+executed by a browser without any warnings.
 
 Validation hooks do not restrict the upload of other executable files
 (like ``*.exe`` or shell scripts). **Those are not automatically executed
@@ -97,32 +98,23 @@ The two built-in validators are extremely simple.
 This just rejects any file for upload. By default this happens for HTML files
 (mime type `text/html``).
 
-.. code-block:: python
-
-    def validate_svg(file_name, file, owner, mime_type):
-        """SVG files must not contain script tags or javascript hrefs.
-        This might be too strict but avoids parsing the xml"""
-        content = file.read().lower()
-        if b"<script" in content or b"javascript:" in content:
-            raise FileValidationError(
-                _('File "{}": Rejected due to potential cross site scripting vulnerability').format(file_name)
-            )
-
-
-This validator rejects any SVG file that contains the bytes ``<script`` or
-``javascript:``. This probably is a too strict criteria, since those bytes
-might be part of a legitimate string. The above code is a simplification
-the actual code also checks for occurrences of event attribute like
-``onclick="..."``.
+The second built-in validator, ``filer.validation.sanitize_svg``, parses
+uploaded SVG files and rewrites them with any scripts, event handlers and
+other non-graphic content removed. It is powered by
+`py-svg-hush <https://pypi.org/project/py-svg-hush/>`_, a Python binding
+for the Rust `svg-hush <https://github.com/kornelski/svg-hush>`_ library.
+Because the sanitizer runs in native code it is fast enough to apply to
+every upload by default.
 
 .. note::
 
-    If you have legitimate SVG files that contain either ``<script`` or
-    ``javascript:`` as byte sequences try escaping the ``<`` and ``:``.
+    The sanitized SVG is not byte-identical to the uploaded file: comments,
+    scripts, event handlers, external references and other potentially
+    dangerous constructs are stripped. The visual appearance of the
+    graphic is preserved.
 
-Clearly, the validator can be improved by parsing the SVG's xml code, but
-this could be error-prone and we decided to go with the potentially too strict
-but simpler method.
+If ``py-svg-hush`` cannot parse the file (for example because it is not a
+valid SVG), the upload is rejected with a ``FileValidationError``.
 
 Common validator settings
 -------------------------
@@ -147,18 +139,18 @@ a malicious file unknowingly.
         "application/octet-stream",
     ]
 
-No HTML upload and restricted SVG upload, no binary or unknown file upload
-...........................................................................
+No HTML upload, sanitized SVG upload, no binary or unknown file upload
+......................................................................
 
-This is the default setting. It will deny any SVG file that might contain
-Javascript. It is prone to false positives (i.e. files being rejected that
-actually are secure).
+This is the default setting. HTML uploads are rejected, SVG uploads are
+sanitized by ``filer.validation.sanitize_svg`` (see above), and binary or
+unknown files are rejected.
 
 .. note::
 
-    If you identify false negatives (i.e. files being
-    accepted despite containing Javascript) please contact the maintainer only
-    through `security@django-cms.org <mailto:security@django-cms.org>`_.
+    If you identify an attack vector that survives ``sanitize_svg`` please
+    contact the maintainer only through
+    `security@django-cms.org <mailto:security@django-cms.org>`_.
 
 
 
@@ -179,33 +171,25 @@ in the user's browser.
 
 (Still not binary or unknown file upload)
 
-Experimental SVG sanitization
-.............................
+Strict SVG rejection (legacy behaviour)
+.......................................
 
-This experimental feature passes an uploaded SVG image through easy-thumbnail
-and is rewritten without non-graphic tags or attributes. Any javascript
-within the SVG file will be lost.
-
-The resulting file is not identical to the uploaded file.
+Previous versions of django-filer shipped with a ``validate_svg`` validator
+that rejected any SVG file containing ``<script``, ``javascript:`` or an
+event handler attribute. It is still available if you prefer rejecting
+suspicious SVGs over rewriting them:
 
 .. code-block:: python
 
     FILER_REMOVE_FILE_VALIDATORS = ["image/svg+xml"]
 
     FILER_ADD_FILE_VALIDATORS = {
-        "image/svg+xml": ["filer.validation.sanitize_svg"],
+        "image/svg+xml": ["filer.validation.validate_svg"],
     }
 
-.. warning::
-
-    This feature is experimental. It is not clear how effective the
-    sanitization is in practice. Use it at own risk.
-
-.. note::
-
-    If you identify an attack vector when using ``sanitize_svg`` please
-    contact us only through
-    `security@django-cms.org <mailto:security@django-cms.org>`_.
+This approach is prone to false positives, since those byte sequences can
+legitimately appear inside SVG text content. ``sanitize_svg`` (the
+default) is usually the better choice.
 
 Block other mime-types
 ----------------------

--- a/filer/apps.py
+++ b/filer/apps.py
@@ -60,7 +60,7 @@ class FilerConfig(AppConfig):
             self.FILE_VALIDATORS[mime_type] = functions
 
     def ready(self):
-        # Make webp mime type known to python (needed for python < 3.11)
+        # Make webp MIME type known to python (needed for python < 3.11)
         mimetypes.add_type("image/webp", ".webp")
         #
         self.resolve_validators()

--- a/filer/settings.py
+++ b/filer/settings.py
@@ -291,7 +291,7 @@ IMAGE_MIME_TYPES = ['gif', 'jpeg', 'png', 'x-png', 'svg+xml', 'webp']
 
 FILE_VALIDATORS = {
     "text/html": ["filer.validation.deny_html"],
-    "image/svg+xml": ["filer.validation.validate_svg"],
+    "image/svg+xml": ["filer.validation.sanitize_svg"],
     "application/octet-stream": ["filer.validation.deny"],
 }
 

--- a/filer/validation.py
+++ b/filer/validation.py
@@ -75,7 +75,7 @@ def validate_svg(file_name: str, file: typing.IO, owner: User, mime_type: str) -
         warnings.warn(
             "SVG validation via string matching is deprecated and will be removed. "
             "SVGs will be sanitized instead. Remove this message by removing "
-            "{\"image/svg+xml\": [\"filer.validation.sanitize_svg\"]} from your " \
+            "{\"image/svg+xml\": [\"filer.validation.sanitize_svg\"]} from your "
             "FILER_ADD_FILE_VALIDATORS settings",
             DeprecationWarning,
             stacklevel=2,
@@ -95,7 +95,7 @@ def sanitize_svg(file_name: str, file: typing.IO, owner: User, mime_type: str) -
         sanitized = filter_svg(content)
     except Exception:
         sanitized = None
-    
+
     if sanitized is None:
         raise FileValidationError(
             _('File "{file_name}": Rejected due to incompatible format')
@@ -105,17 +105,17 @@ def sanitize_svg(file_name: str, file: typing.IO, owner: User, mime_type: str) -
     file.seek(0)  # Rewind file
     file.truncate()  # Delete old content
     file.write(sanitized)  # write to binary file with utf-8 encoding
-    
+
 
 def validate_upload(file_name: str, file: typing.IO, owner: User, mime_type: str) -> None:
-    """Actual validation: Call all validators for the given mime type. The app config reads
+    """Actual validation: Call all validators for the given MIME type. The app config reads
     the validators from the settings and replaces dotted paths by callables."""
 
     config = apps.get_app_config("filer")
 
     # First, check white list if provided
     if config.MIME_TYPE_WHITELIST:
-        # FILER_MIME_TYPE_WHITELIST restricts the allowed mime types to, e.g., "image/*" or "text/plain"
+        # FILER_MIME_TYPE_WHITELIST restricts the allowed MIME types to, e.g., "image/*" or "text/plain"
         for allowed_mime_type in config.MIME_TYPE_WHITELIST:
             if mime_type == allowed_mime_type:
                 break

--- a/filer/validation.py
+++ b/filer/validation.py
@@ -93,7 +93,7 @@ def sanitize_svg(file_name: str, file: typing.IO, owner: User, mime_type: str) -
     content = file.read()
     try:
         sanitized = filter_svg(content)
-    except Exception:
+    except ValueError:
         sanitized = None
 
     if sanitized is None:

--- a/filer/validation.py
+++ b/filer/validation.py
@@ -38,35 +38,48 @@ def deny_html(file_name: str, file: typing.IO, owner: User, mime_type: str) -> N
 TRIGGER_XSS_THREAD = (
     # Part 1: Event attributes that take js code as values
     # See https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/Events
-    b"onbegin=", b"onend=", b"onrepeat=",
-    b"onabort=", b"onerror=", b"onresize=", b"onscroll=", b"onunload=",
-    b"oncopy=", b"oncut=", b"onpaste=",
-    b"oncancel=", b"oncanplay=", b"oncanplaythrough=", b"onchange=", b"onclick=", b"onclose=", b"oncuechange=", b"ondblclick=",
-    b"ondrag=", b"ondragend=", b"ondragenter=", b"ondragleave=", b"ondragover=", b"ondragstart=", b"ondrop=",
-    b"ondurationchange=", b"onemptied=", b"onended=", b"onerror=", b"onfocus=", b"oninput=", b"oninvalid=",
-    b"onkeydown=", b"onkeypress=", b"onkeyup=", b"onload=", b"onloadeddata=", b"onloadedmetadata=", b"onloadstart=",
-    b"onmousedown=", b"onmouseenter=", b"onmouseleave=", b"onmousemove=", b"onmouseout=", b"onmouseover=", b"onmouseup=",
-    b"onmousewheel=", b"onpause=", b"onplay=", b"onplaying=", b"onprogress=", b"onratechange=", b"onreset=", b"onresize=",
-    b"onscroll=", b"onseeked=", b"onseeking=", b"onselect=", b"onshow=", b"onstalled=", b"onsubmit=", b"onsuspend=",
-    b"ontimeupdate=", b"ontoggle==", b"onvolumechange==", b"onwaiting=",
-    b"onactivate=", b"onfocusin=", b"onfocusout=",
+    "onbegin=", "onend=", "onrepeat=",
+    "onabort=", "onerror=", "onresize=", "onscroll=", "onunload=",
+    "oncopy=", "oncut=", "onpaste=",
+    "oncancel=", "oncanplay=", "oncanplaythrough=", "onchange=", "onclick=", "onclose=", "oncuechange=", "ondblclick=",
+    "ondrag=", "ondragend=", "ondragenter=", "ondragleave=", "ondragover=", "ondragstart=", "ondrop=",
+    "ondurationchange=", "onemptied=", "onended=", "onerror=", "onfocus=", "oninput=", "oninvalid=",
+    "onkeydown=", "onkeypress=", "onkeyup=", "onload=", "onloadeddata=", "onloadedmetadata=", "onloadstart=",
+    "onmousedown=", "onmouseenter=", "onmouseleave=", "onmousemove=", "onmouseout=", "onmouseover=", "onmouseup=",
+    "onmousewheel=", "onpause=", "onplay=", "onplaying=", "onprogress=", "onratechange=", "onreset=", "onresize=",
+    "onscroll=", "onseeked=", "onseeking=", "onselect=", "onshow=", "onstalled=", "onsubmit=", "onsuspend=",
+    "ontimeupdate=", "ontoggle=", "onvolumechange=", "onwaiting=",
+    "onactivate=", "onfocusin=", "onfocusout=",
 ) + (
     # Part 2:
     # Reject base64 obfuscated content
-    b";base64,",
+    ";base64,",
 ) + (
     # Part 3: Obvious scripts
     # Reject direct <scrpit> tags or javascript: uri
-    b"<script",
-    b"javascript:",
+    "<script",
+    "javascript:",
 )
 
 
 def validate_svg(file_name: str, file: typing.IO, owner: User, mime_type: str) -> None:
     """SVG files must not contain script tags or javascript hrefs.
     This might be too strict but avoids parsing the xml"""
-    content = file.read().lower()
+
+    from html import unescape
+
+    content = unescape(file.read().decode('utf-8').lower())
     if any(map(lambda x: x in content, TRIGGER_XSS_THREAD)):
+        import warnings
+
+        warnings.warn(
+            "SVG validation via string matching is deprecated and will be removed. "
+            "SVGs will be sanitized instead. Remove this message by removing "
+            "{\"image/svg+xml\": [\"filer.validation.sanitize_svg\"]} from your " \
+            "FILER_ADD_FILE_VALIDATORS settings",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # If any element of TRIGGER_XSS_THREAD is found in file, raise FileValidationError
         raise FileValidationError(
             _('File "{file_name}": Rejected due to potential cross site scripting vulnerability')
@@ -75,21 +88,24 @@ def validate_svg(file_name: str, file: typing.IO, owner: User, mime_type: str) -
 
 
 def sanitize_svg(file_name: str, file: typing.IO, owner: User, mime_type: str) -> None:
-    from easy_thumbnails.VIL.Image import Image
-    from reportlab.graphics import renderSVG
-    from svglib.svglib import svg2rlg
-    drawing = svg2rlg(file)
-    if not drawing:
+    from py_svg_hush import filter_svg
+
+    content = file.read()
+    try:
+        sanitized = filter_svg(content)
+    except Exception:
+        sanitized = None
+    
+    if sanitized is None:
         raise FileValidationError(
-            _('File "{file_name}": SVG file format not recognized')
+            _('File "{file_name}": Rejected due to incompatible format')
             .format(file_name=file_name)
         )
-    image = Image(size=(drawing.width, drawing.height))
-    renderSVG.draw(drawing, image.canvas)
-    xml = image.canvas.svg.toxml(encoding="UTF-8")  # Removes non-graphic nodes ->  sanitation
-    file.seek(0)  # Rewind file
-    file.write(xml)  # write to binary file with utf-8 encoding
 
+    file.seek(0)  # Rewind file
+    file.truncate()  # Delete old content
+    file.write(sanitized)  # write to binary file with utf-8 encoding
+    
 
 def validate_upload(file_name: str, file: typing.IO, owner: User, mime_type: str) -> None:
     """Actual validation: Call all validators for the given mime type. The app config reads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ dependencies = [
     # which requires system-level libraries and fails to install in the container.
     # This can be removed once the issue is resolved.
     # See: https://github.com/deeplook/svglib/issues/421
-    "svglib~=1.5.1"
+    "svglib~=1.5.1",
+    "py-svg-hush",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -52,6 +53,7 @@ classifiers = [
     "Framework :: Django CMS :: 4.0",
     "Framework :: Django CMS :: 4.1",
     "Framework :: Django CMS :: 5.0",
+    "Framework :: Django CMS :: 5.1",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     "Topic :: Software Development",

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -343,7 +343,7 @@ class FilerImageAdminUrlsTests(TestCase):
 
     def test_image_expand_link_in_change_view(self):
         files = [
-            # Files can use the same contents for this test - it's the mime type that counts
+            # Files can use the same contents for this test - it's the MIME type that counts
             File.objects.create(owner=self.superuser, original_filename='some-file.txt', file=self.file_object.file),
             Image.objects.create(owner=self.superuser, original_filename='some-image.jpg'),  # missing file
             Image.objects.create(owner=self.superuser, original_filename='some-image.jpg', file=self.file_object.file),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,7 +68,7 @@ class ZippingTestCase(TestCase):
 
 class MimeTypesTestCase(TestCase):
     def test_mime_types_known(self):
-        """Ensure that for all IMAGE_EXTENSIONS the mime types can be identified"""
+        """Ensure that for all IMAGE_EXTENSIONS the MIME types can be identified"""
         for ext in IMAGE_EXTENSIONS:
             self.assertIsNotNone(mimetypes.guess_type(f"file{ext}")[0],
                                  f"Mime type for extension {ext} unknown")

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -128,9 +128,6 @@ stroke="#004400"/>
         )
 
     def test_svg_sanitizer(self):
-        config = apps.get_app_config("filer")
-        svg_validation = config.FILE_VALIDATORS["image/svg+xml"]
-        config.FILE_VALIDATORS["image/svg+xml"] = [sanitize_svg]
         for attack, disallowed in [
             ("""<a href="javascript: alert('ing');">test</a>""", "javascript:"),
             ('<script>alert(document.domain);</script>', "alert"),
@@ -155,12 +152,11 @@ stroke="#004400"/>
                     'jsessionid': self.client.session.session_key
                 }
                 response = self.client.post(url, post_data)
-            file_id = json.loads(response.content.decode("utf-8"))["file_id"]
+            result = json.loads(response.content.decode("utf-8"))
+            file_id = result["file_id"]
             img = File.objects.get(pk=file_id)
             content = img.file.file.read().decode("utf-8")
             self.assertNotIn(disallowed, content)
-
-        config.FILE_VALIDATORS["image/svg+xml"] = svg_validation
 
 
 class TestWhitelist(TestCase):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 
 from filer.models import File, Folder
-from filer.validation import FileValidationError, validate_upload, validate_svg
+from filer.validation import FileValidationError, sanitize_svg, validate_svg, validate_upload
 from tests.helpers import create_superuser
 
 
@@ -126,6 +126,18 @@ stroke="#004400"/>
             None,
             "text/html",
         )
+
+    def test_svg_validator_rejects_non_svg_file(self):
+        import io
+
+        non_svg_content = b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01'
+        file_obj = io.BytesIO(non_svg_content)
+
+        with self.assertRaisesRegex(
+            FileValidationError,
+            "Rejected due to incompatible format",
+        ):
+            sanitize_svg("test_file.svg", file_obj, self.superuser, "image/svg+xml")
 
     def test_svg_sanitizer(self):
         for attack, disallowed in [

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 
 from filer.models import File, Folder
-from filer.validation import FileValidationError, validate_upload, sanitize_svg
+from filer.validation import FileValidationError, validate_upload, sanitize_svg, validate_svg
 from tests.helpers import create_superuser
 
 
@@ -57,9 +57,14 @@ stroke="#004400"/>
         self.assertEqual(File.objects.count(), 0)
 
     def test_svg_upload_fails(self):
+        config = apps.get_app_config("filer")
+        svg_validation = config.FILE_VALIDATORS["image/svg+xml"]
+        config.FILE_VALIDATORS["image/svg+xml"] = [validate_svg]
+
         for attack, expected_files in [
             ("""<a href="javascript: alert('ing');">test</a>""", 0),
             ('<script>alert(document.domain);</script>', 0),
+            ('&#x3c;script>alert(document.domain);</script>', 0),
             ("""<circle onclick="console.log('test')" cx="300" cy="225" r="100" fill="red"/>""", 0),
             ("", 1)
         ]:
@@ -86,6 +91,8 @@ stroke="#004400"/>
             if expected_files == 0:
                 self.assertContains(response, "Rejected due to potential cross site scripting vulnerability")
             self.assertEqual(File.objects.count(), n + expected_files)
+
+        config.FILE_VALIDATORS["image/svg+xml"] = svg_validation
 
     def test_deny_validator(self):
         from filer.validation import deny

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from django.utils.crypto import get_random_string
 
 from filer.models import File, Folder
-from filer.validation import FileValidationError, validate_upload, sanitize_svg, validate_svg
+from filer.validation import FileValidationError, validate_upload, validate_svg
 from tests.helpers import create_superuser
 
 


### PR DESCRIPTION
## Description

This PR addresses a stored Cross-Site Scripting (XSS) vulnerability uploading an SVG and bypassing the SVG validation.

### Summary

The issue originates from an oversimplified SVG validation routine. Due to the complexity of the format, we deprecated the SVG validation altogether (though in this PR closing the loophole used to show this issue) and fully start relying on SVG sanitation. To this end this PR adds a new dependency to "py-svg-hush" which provides python bindings for the rust-based "svg-hush" library. 

### Impact

This vulnerability could allow an attacker with low-privileged CMS access to:

* Execute arbitrary JavaScript a viewer's browser
* Hijack sessions via document.cookie

### Fix

By default the SVG sanitation is activated (before: only validation). SVG validation triggers a deprecation warning and will be removed.

## 🙏 Acknowledgements

We would like to sincerely thank the security researcher who reported this issue:

* Ashwak N <ashwakn04@gmail.com>

Security contributions like these are incredibly valuable to a community-driven project like django Filer. Responsible disclosure helps ensure the safety of all users and strengthens the ecosystem as a whole.

## Summary by Sourcery

Enable sanitization-based handling of uploaded SVG files and deprecate the previous string-matching SVG validation to close an XSS vector.

New Features:
- Introduce SVG sanitization based on the py-svg-hush library for processing uploaded SVG files.

Bug Fixes:
- Fix an SVG upload XSS vulnerability by correctly detecting script content, including HTML-encoded payloads, during validation.

Enhancements:
- Deprecate the legacy SVG string-matching validator in favor of sanitizer-based handling and emit a deprecation warning when it is used.

Build:
- Add the py-svg-hush dependency and update project classifiers to include Django CMS 5.1 support.

Tests:
- Extend SVG upload tests to cover encoded script payloads and explicitly exercise the deprecated SVG validator.