### PR TITLE
chore: upgrade GitHub Actions versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,16 +27,16 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
         if: ${{ matrix.language == 'javascript' || matrix.language == 'python' }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install flake8
         run: pip install --upgrade flake8 flake8-pyproject
       - name: Run flake8
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: flake8
           run: flake8
@@ -32,7 +32,7 @@ jobs:
           python-version: 3.9
       - run: python -m pip install isort
       - name: isort
-        uses: liskin/gh-problem-matcher-wrap@v1
+        uses: liskin/gh-problem-matcher-wrap@v3
         with:
           linters: isort
           run: isort -c --df filer

--- a/.github/workflows/pre-commit.ci.yaml
+++ b/.github/workflows/pre-commit.ci.yaml
@@ -7,8 +7,8 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: 3.x
     - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,4 +58,4 @@ jobs:
     - name: Run coverage
       run: coverage run ./tests/settings.py
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6


### PR DESCRIPTION
## Summary
- upgrade outdated GitHub Actions versions listed in the repository audit
- align workflow action references with their current supported versions

## Testing
- not run (workflow-only change)

## Summary by Sourcery

Build:
- Bump CodeQL, liskin problem-matcher, checkout, setup-python, and Codecov actions to newer major versions across CI workflows.