### PR TITLE
fix: Treat misconfigs more gracefully

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -82,6 +82,18 @@ To enable automatic subject location aware cropping of images replace
         'easy_thumbnails.processors.filters',
     )
 
+.. IMPORTANT::
+
+    Keep ``easy_thumbnails.processors.colorspace`` as the first entry of
+    ``THUMBNAIL_PROCESSORS`` (it is part of easy-thumbnails' default chain).
+    This processor converts indexed/palette images – most notably GIFs, which
+    use Pillow's ``P`` mode – into ``RGB`` (or ``RGBA`` for transparent images).
+    Thumbnails are saved as JPEG by default, and the JPEG encoder cannot write
+    palette images: without ``colorspace`` running first, generating a thumbnail
+    for such a file fails with ``OSError: cannot write mode P as JPEG`` (see
+    issue #1601). Because it has to run before the image is resized, it must
+    come before the scaling/cropping processors.
+
 To crop an image and respect the subject location::
 
     {% load thumbnail %}

--- a/filer/admin/fileadmin.py
+++ b/filer/admin/fileadmin.py
@@ -221,7 +221,7 @@ class FileAdmin(PrimitivePermissionAwareModelAdmin):
             # Touch thumbnail to allow it to be prefetched for directory listing
             EasyThumbnail.objects.filter(name=thumbnail.name).update(modified=now())
             return HttpResponseRedirect(thumbnail.url)
-        except (InvalidImageFormatError, NoSourceGenerator):
+        except (InvalidImageFormatError, NoSourceGenerator, OSError):
             return HttpResponseRedirect(staticfiles_storage.url('filer/icons/file-missing.svg'))
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -305,6 +305,65 @@ class FilerImageAdminUrlsTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertIn("icons/file-missing.svg", response["Location"])
 
+    def test_icon_view_palette_gif(self):
+        """A palette-mode GIF generates a JPEG thumbnail with ``colorspace`` (#1601)
+
+        The ``colorspace`` processor converts the palette ("P") image to RGB, so
+        the JPEG thumbnail can be written and a real thumbnail is returned.
+        """
+        gif_name = 'palette.gif'
+        gif_path = os.path.join(settings.FILE_UPLOAD_TEMP_DIR, gif_name)
+        create_image(mode='P', size=(200, 150)).save(gif_path, 'GIF')
+        try:
+            with open(gif_path, 'rb') as upload:
+                image = Image.objects.create(
+                    file=django.core.files.File(upload, name=gif_name),
+                )
+            url = reverse('admin:filer_file_fileicon', kwargs={
+                'file_id': image.pk,
+                'size': 80,
+            })
+            response = self.client.get(url)
+
+            self.assertEqual(response.status_code, 302)
+            # A real (media) thumbnail is generated, not the missing-file icon.
+            self.assertIn("/media/", response["Location"])
+            self.assertNotIn("icons/file-missing.svg", response["Location"])
+        finally:
+            os.remove(gif_path)
+
+    def test_icon_view_unencodable_image(self):
+        """Icon generation degrades gracefully when a thumbnail can't be encoded (#1601)
+
+        If ``colorspace`` is not part of ``THUMBNAIL_PROCESSORS``, a palette-mode
+        ("P") GIF reaches the JPEG encoder unchanged and raises
+        ``OSError: cannot write mode P as JPEG``. The icon view must fall back to
+        the missing-file icon instead of returning a 500.
+        """
+        gif_name = 'palette.gif'
+        gif_path = os.path.join(settings.FILE_UPLOAD_TEMP_DIR, gif_name)
+        create_image(mode='P', size=(200, 150)).save(gif_path, 'GIF')
+        try:
+            with open(gif_path, 'rb') as upload:
+                image = Image.objects.create(
+                    file=django.core.files.File(upload, name=gif_name),
+                )
+            url = reverse('admin:filer_file_fileicon', kwargs={
+                'file_id': image.pk,
+                'size': 80,
+            })
+            with SettingsOverride(settings, THUMBNAIL_PROCESSORS=(
+                'easy_thumbnails.processors.autocrop',
+                'filer.thumbnail_processors.scale_and_crop_with_subject_location',
+                'easy_thumbnails.processors.filters',
+            )):
+                response = self.client.get(url)
+
+            self.assertEqual(response.status_code, 302)
+            self.assertIn("icons/file-missing.svg", response["Location"])
+        finally:
+            os.remove(gif_path)
+
     def test_icon_view_non_image(self):
         """Getting an icon for a non-image results in a 404"""
         file = File.objects.create(


### PR DESCRIPTION

## Summary by Sourcery

Handle failures during admin file icon thumbnail generation more gracefully and add coverage for palette GIFs and misconfigured thumbnail processors.

Bug Fixes:
- Ensure the admin file icon view falls back to the missing-file icon when thumbnail generation raises an OSError instead of returning a server error.

Tests:
- Add tests verifying icon generation for palette-mode GIFs both when thumbnails are successfully generated and when misconfigured processors require falling back to the missing-file icon.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #1601 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
