### PR TITLE
chore: Unpin svglib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,6 @@ dependencies = [
     "django>=3.2",
     "django-polymorphic<5.0",
     "easy-thumbnails[svg]",
-
-    # Pin svglib to a version below 1.6.0.
-    # The latest version (1.6.0) adds pycairo as a dependency,
-    # which requires system-level libraries and fails to install in the container.
-    # This can be removed once the issue is resolved.
-    # See: https://github.com/deeplook/svglib/issues/421
-    "svglib~=1.5.1",
     "py-svg-hush",
 ]
 classifiers = [


### PR DESCRIPTION
## Description

svglib moved pycairo to optional dependencies with version 2.x

## Related resources

* https://github.com/deeplook/svglib/issues/421#issuecomment-4548088067

## Checklist

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
