### PR TITLE
fix: Delete folder action failed to check all permissions

### DIFF
--- a/filer/admin/folderadmin.py
+++ b/filer/admin/folderadmin.py
@@ -756,6 +756,13 @@ class FolderAdmin(PrimitivePermissionAwareModelAdmin):
         if not self.has_delete_permission(request):
             raise PermissionDenied
 
+        # Check that the user has per-folder edit permission on every selected
+        # file and folder (and their descendants). Without this, a user with
+        # only read access to a folder could delete its contents when the
+        # optional per-folder permission system is enabled.
+        check_files_edit_permissions(request, files_queryset)
+        check_folder_edit_permissions(request, folders_queryset)
+
         current_folder = self._get_current_action_folder(
             request, files_queryset, folders_queryset)
 

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -418,11 +418,12 @@ class FolderPermissionsTestCase(TestCase):
             # A folder (owned by someone else) containing a file. test_user1 can
             # read it but must not be able to delete it.
             target = Folder.objects.create(name="readonly_target", owner=self.superuser)
-            target_file = DjangoFile(open(self.filename, "rb"), name="inside.jpg")
-            inside = Image.objects.create(
-                owner=self.superuser, original_filename="inside.jpg",
-                file=target_file, folder=target,
-            )
+            with open(self.filename, "rb") as opened_file:
+                target_file = DjangoFile(opened_file, name="inside.jpg")
+                inside = Image.objects.create(
+                    owner=self.superuser, original_filename="inside.jpg",
+                    file=target_file, folder=target,
+                )
 
             self.assertTrue(
                 self.client.login(username=self.test_user1.username, password="secret")

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -389,6 +389,61 @@ class FolderPermissionsTestCase(TestCase):
         perm = FolderPermission.objects.create()
         self.assertEqual(perm.who, "–")
 
+    def test_delete_action_requires_edit_permission(self):
+        # A staff user with only read access to a folder (can_read=ALLOW,
+        # can_edit=DENY) plus the model-level delete permissions must NOT be
+        # able to delete files/folders through the bulk delete action.
+        old_setting = filer_settings.FILER_ENABLE_PERMISSIONS
+        target_file = None
+        try:
+            filer_settings.FILER_ENABLE_PERMISSIONS = True
+
+            # Grant the model-level delete permissions to test_user1.
+            delete_perms = Permission.objects.filter(
+                codename__in=("delete_folder", "delete_file", "delete_image")
+            )
+            self.test_user1.user_permissions.add(*delete_perms)
+
+            # Read allowed / edit denied on *all* folders. Using an "everybody"
+            # permission means no FolderPermission row is attached to the target
+            # folder itself, so the only thing that can block the deletion is
+            # the missing edit permission (which is what we are testing).
+            FolderPermission.objects.create(
+                type=FolderPermission.ALL, everybody=True,
+                can_edit=FolderPermission.DENY,
+                can_read=FolderPermission.ALLOW,
+                can_add_children=FolderPermission.DENY,
+            )
+
+            # A folder (owned by someone else) containing a file. test_user1 can
+            # read it but must not be able to delete it.
+            target = Folder.objects.create(name="readonly_target", owner=self.superuser)
+            target_file = DjangoFile(open(self.filename, "rb"), name="inside.jpg")
+            inside = Image.objects.create(
+                owner=self.superuser, original_filename="inside.jpg",
+                file=target_file, folder=target,
+            )
+
+            self.assertTrue(
+                self.client.login(username=self.test_user1.username, password="secret")
+            )
+
+            url = reverse('admin:filer-directory_listing-root')
+            response = self.client.post(url, {
+                'action': 'delete_files_or_folders',
+                'post': 'yes',
+                helpers.ACTION_CHECKBOX_NAME: ['folder-%d' % target.id],
+            })
+            self.assertEqual(response.status_code, 403)
+            # Neither the folder nor the file it contains may be deleted.
+            self.assertTrue(Folder.objects.filter(pk=target.pk).exists())
+            self.assertTrue(Image.objects.filter(pk=inside.pk).exists())
+        finally:
+            filer_settings.FILER_ENABLE_PERMISSIONS = old_setting
+            if target_file is not None:
+                target_file.close()
+            cache.clear()
+
     def test_folderpermission_is_copied(self):
         source_folder = Folder.objects.create(name="source")
         destination_folder = Folder.objects.create(name="destination")


### PR DESCRIPTION
## Summary by Sourcery

Ensure bulk delete actions respect per-folder edit permissions and add regression coverage for permission checks.

Bug Fixes:
- Prevent users with only read access and model-level delete permission from deleting folders and files via the bulk delete action.

Tests:
- Add a regression test verifying that delete actions require edit permission when folder-level permissions are enabled.

The underlying issue was reported by Ta Duc Thien

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* #...
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.