### PR TITLE
feat: Add Django 6.1 support

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,5 +26,5 @@ Use 'x' to check each item: [x] I have ...
 * [ ] I have opened this pull request against ``master``
 * [ ] I have added or modified the tests when changing logic
 * [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
-* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
-[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
+* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #pr-reviews on
+[Discord](https://www.django-cms.org/dicord) to find a “pr review buddy” who is going to review my pull request.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
           django-5.1.txt,
           django-5.2.txt,
           django-6.0.txt,
+          django-6.1.txt,
           django-main.txt,
         ]
         custom-image-model: [false, true]
@@ -28,6 +29,10 @@ jobs:
           - requirements-file: django-6.0.txt
             python-version: 3.10
           - requirements-file: django-6.0.txt
+            python-version: 3.11
+          - requirements-file: django-6.1.txt
+            python-version: 3.10
+          - requirements-file: django-6.1.txt
             python-version: 3.11
           - requirements-file: django-4.2.txt
             python-version: 3.14

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,24 @@
 CHANGELOG
 =========
 
+3.6.0 (unreleased)
+==================
+
+* feat: Add support for Django 6.1. The admin breadcrumbs now render as
+  ``<ol class="breadcrumbs">`` on Django 6.1 and later, matching the markup its
+  element-qualified CSS selectors expect, and keep the legacy
+  ``<div class="breadcrumbs">`` markup on older versions.
+* ci: Test against Django 6.0 and 6.1.
+
+.. note::
+
+   Projects that override one of filer's breadcrumb templates
+   (``admin/filer/breadcrumbs.html``, ``admin/filer/folder/change_form.html``, or the
+   new ``admin/filer/folder/listing_breadcrumbs.html``, which replaces the duplicated
+   breadcrumb blocks of ``directory_listing.html`` and ``legacy_listing.html``) need to
+   emit the Django 6.1 markup themselves to stay styled. Use the
+   ``{% django_version_gte 6 1 %}`` tag from ``filer_admin_tags`` to support both.
+
 3.5.1 (2026-08-26)
 ==================
 

--- a/filer/templates/admin/filer/breadcrumbs.html
+++ b/filer/templates/admin/filer/breadcrumbs.html
@@ -1,5 +1,24 @@
 {% load i18n filer_admin_tags %}
+{% django_version_gte 6 1 as new_breadcrumbs %}
 
+{% if new_breadcrumbs %}
+<ol class="breadcrumbs">
+    <li><a href="{% url 'admin:index' %}" title="{% translate 'Go back to admin homepage' %}">{% translate "Home" %}</a></li>
+    <li><a href="{% url 'admin:app_list' app_label='filer' %}" title="{% translate 'Go back to Filer app' %}">{% translate "Filer" %}</a></li>
+    <li><a href="{% url 'admin:filer-directory_listing-root' %}{% filer_admin_context_url_params %}" title="{% translate 'Go back to root folder' %}">{% translate "Folder" %}</a></li>
+    {% for ancestor_folder in instance.logical_path %}
+        <li><a href="{{ ancestor_folder.get_admin_directory_listing_url_path }}{% filer_admin_context_url_params %}" title="{% blocktranslate with folder_name=ancestor_folder.name %}Go back to '{{ folder_name }}' folder{% endblocktranslate %}">{% if ancestor_folder.label %}{{ ancestor_folder.label }}{% else %}{{ ancestor_folder.name }}{% endif %}</a></li>
+    {% endfor %}
+    {% if breadcrumbs_action %}
+        {% if instance.label or instance.name %}
+            <li><a href="{{ instance.get_admin_directory_listing_url_path }}{% filer_admin_context_url_params %}" title="{% blocktranslate with folder_name=instance.name %}Go back to '{{ folder_name }}' folder{% endblocktranslate %}">{% if instance.label %}{{ instance.label }}{% else %}{{ instance.name }}{% endif %}</a></li>
+        {% endif %}
+        <li aria-current="page">{{ breadcrumbs_action }}</li>
+    {% else %}
+        <li aria-current="page">{% if instance.label %}{{ instance.label }}{% else %}{{ instance.name }}{% endif %}</li>
+    {% endif %}
+</ol>
+{% else %}
 <div class="breadcrumbs">
     <a href="{% url 'admin:index' %}" title="{% translate 'Go back to admin homepage' %}">{% translate "Home" %}</a>
     &rsaquo; <a href="{% url 'admin:app_list' app_label='filer' %}" title="{% translate 'Go back to Filer app' %}"> {% translate "Filer" %}</a>
@@ -22,3 +41,4 @@
         &rsaquo; {% if instance.label %}{{ instance.label }}{% else %}{{ instance.name }}{% endif %}
     {% endif %}
 </div>
+{% endif %}

--- a/filer/templates/admin/filer/folder/change_form.html
+++ b/filer/templates/admin/filer/folder/change_form.html
@@ -2,6 +2,18 @@
 {% load i18n admin_modify static filer_admin_tags %}
 
 {% block breadcrumbs %}
+    {% django_version_gte 6 1 as new_breadcrumbs %}
+    {% if new_breadcrumbs %}
+    <ol class="breadcrumbs">
+        <li><a href="{% url 'admin:index' %}" title="{% translate 'Go back to' %} {% translate 'admin homepage' %}">{% translate "Home" %}</a></li>
+        <li><a href="{% url 'admin:app_list' app_label='filer' %}" title="{% translate 'Go back to' %} {% translate 'Filer' %}">{% translate "Filer" %}</a></li>
+        <li><a href="{% url 'admin:filer-directory_listing-root' %}" title="{% translate 'Go back to' %} '{% translate 'root'|title %}' {% translate 'folder' %}">{% translate "root"|title %}</a></li>
+        {% for ancestor_folder in original.logical_path %}
+            <li><a href="{% url 'admin:filer-directory_listing' ancestor_folder.id %}" title="{% blocktranslate with folder_name=ancestor_folder.name %}Go back to '{{ folder_name }}' folder{% endblocktranslate %}">{{ ancestor_folder.name }}</a></li>
+        {% endfor %}
+        <li aria-current="page">{{ original.name }}</li>
+    </ol>
+    {% else %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}" title="{% translate 'Go back to' %} {% translate 'admin homepage' %}">{% translate "Home" %}</a>
         &rsaquo; <a href="{% url 'admin:app_list' app_label='filer' %}" title="{% translate 'Go back to' %} {% translate 'Filer' %}"> {% translate "Filer" %}</a>
@@ -11,6 +23,7 @@
         {% endfor %}
         &rsaquo; {{ original.name }}
     </div>
+    {% endif %}
 {% endblock %}
 
 {% block coltype %}{% if is_popup %}colM{% else %}colMS{% endif %}{% endblock %}

--- a/filer/templates/admin/filer/folder/directory_listing.html
+++ b/filer/templates/admin/filer/folder/directory_listing.html
@@ -24,46 +24,7 @@
 
 {% block breadcrumbs %}
    {% if not is_popup %}
-        <div class="breadcrumbs">
-            <a href="{% url 'admin:index' %}" title="{% trans 'Go back to admin homepage' %}">
-                {% trans "Home" %}
-            </a>
-            &rsaquo;
-            <a href="{% url 'admin:app_list' app_label='filer' %}" title="{% trans 'Go back to Filer app' %}">
-                {% trans "Filer" %}
-            </a>
-            &rsaquo; <a href="{% url 'admin:filer-directory_listing-root' %}{% filer_admin_context_url_params %}" title="{% translate 'Go back to root folder' %}">{% translate "Folder" %}</a>
-            {% for ancestor_folder in folder.logical_path %}
-                &rsaquo;
-                <a href="{{ ancestor_folder.get_admin_directory_listing_url_path }}{% filer_admin_context_url_params %}"
-                    title="{% blocktrans with ancestor_folder.name as folder_name %}Go back to '{{ folder_name }}' folder{% endblocktrans %}">
-                    {% if ancestor_folder.label %}{{ ancestor_folder.label }}{% else %}{{ ancestor_folder.name }}{% endif %}
-                </a>
-            {% endfor %}
-            &rsaquo; {% if folder.label %}{{ folder.label }}{% else %}{{ folder.name }}{% endif %}
-            {% if breadcrumbs_action %}
-                &rsaquo;
-                <a href="{{ folder.get_admin_directory_listing_url_path }}"
-                    title="{% blocktrans with folder.name as folder_name %}Go back to '{{ folder_name }}' folder{% endblocktrans %}">
-                    {% if folder.label %}
-                        {{ folder.label }}
-                    {% else %}
-                        {{ folder.name }}
-                    {% endif %}
-                </a>
-                &rsaquo;
-                {{ breadcrumbs_action }}
-            {% else %}
-                {% if not instance.is_root and instance.is_smart_folder %}
-                    &rsaquo;
-                {% endif %}
-                {% if instance.label %}
-                    {{ instance.label }}
-                {% else %}
-                    {{ instance.name }}
-                {% endif %}
-            {% endif %}
-        </div>
+        {% include "admin/filer/folder/listing_breadcrumbs.html" %}
     {% endif %}
 {% endblock %}
 

--- a/filer/templates/admin/filer/folder/legacy_listing.html
+++ b/filer/templates/admin/filer/folder/legacy_listing.html
@@ -27,46 +27,7 @@
 
 {% block breadcrumbs %}
    {% if not is_popup %}
-        <div class="breadcrumbs">
-            <a href="{% url 'admin:index' %}" title="{% trans 'Go back to admin homepage' %}">
-                {% trans "Home" %}
-            </a>
-            &rsaquo;
-            <a href="{% url 'admin:app_list' app_label='filer' %}" title="{% trans 'Go back to Filer app' %}">
-                {% trans "Filer" %}
-            </a>
-            &rsaquo; <a href="{% url 'admin:filer-directory_listing-root' %}{% filer_admin_context_url_params %}" title="{% translate 'Go back to root folder' %}">{% translate "Folder" %}</a>
-            {% for ancestor_folder in folder.logical_path %}
-                &rsaquo;
-                <a href="{{ ancestor_folder.get_admin_directory_listing_url_path }}{% filer_admin_context_url_params %}"
-                    title="{% blocktrans with ancestor_folder.name as folder_name %}Go back to '{{ folder_name }}' folder{% endblocktrans %}">
-                    {% if ancestor_folder.label %}{{ ancestor_folder.label }}{% else %}{{ ancestor_folder.name }}{% endif %}
-                </a>
-            {% endfor %}
-            &rsaquo; {% if folder.label %}{{ folder.label }}{% else %}{{ folder.name }}{% endif %}
-            {% if breadcrumbs_action %}
-                &rsaquo;
-                <a href="{{ folder.get_admin_directory_listing_url_path }}"
-                    title="{% blocktrans with folder.name as folder_name %}Go back to '{{ folder_name }}' folder{% endblocktrans %}">
-                    {% if folder.label %}
-                        {{ folder.label }}
-                    {% else %}
-                        {{ folder.name }}
-                    {% endif %}
-                </a>
-                &rsaquo;
-                {{ breadcrumbs_action }}
-            {% else %}
-                {% if not instance.is_root and instance.is_smart_folder %}
-                    &rsaquo;
-                {% endif %}
-                {% if instance.label %}
-                    {{ instance.label }}
-                {% else %}
-                    {{ instance.name }}
-                {% endif %}
-            {% endif %}
-        </div>
+        {% include "admin/filer/folder/listing_breadcrumbs.html" %}
     {% endif %}
 {% endblock %}
 

--- a/filer/templates/admin/filer/folder/listing_breadcrumbs.html
+++ b/filer/templates/admin/filer/folder/listing_breadcrumbs.html
@@ -1,0 +1,64 @@
+{% load i18n filer_admin_tags %}
+{% django_version_gte 6 1 as new_breadcrumbs %}
+
+{% if new_breadcrumbs %}
+<ol class="breadcrumbs">
+    <li><a href="{% url 'admin:index' %}" title="{% translate 'Go back to admin homepage' %}">{% translate "Home" %}</a></li>
+    <li><a href="{% url 'admin:app_list' app_label='filer' %}" title="{% translate 'Go back to Filer app' %}">{% translate "Filer" %}</a></li>
+    <li><a href="{% url 'admin:filer-directory_listing-root' %}{% filer_admin_context_url_params %}" title="{% translate 'Go back to root folder' %}">{% translate "Folder" %}</a></li>
+    {% for ancestor_folder in folder.logical_path %}
+        <li><a href="{{ ancestor_folder.get_admin_directory_listing_url_path }}{% filer_admin_context_url_params %}" title="{% blocktranslate with folder_name=ancestor_folder.name %}Go back to '{{ folder_name }}' folder{% endblocktranslate %}">{% if ancestor_folder.label %}{{ ancestor_folder.label }}{% else %}{{ ancestor_folder.name }}{% endif %}</a></li>
+    {% endfor %}
+    {% if breadcrumbs_action %}
+        <li>{% if folder.label %}{{ folder.label }}{% else %}{{ folder.name }}{% endif %}</li>
+        <li><a href="{{ folder.get_admin_directory_listing_url_path }}" title="{% blocktranslate with folder_name=folder.name %}Go back to '{{ folder_name }}' folder{% endblocktranslate %}">{% if folder.label %}{{ folder.label }}{% else %}{{ folder.name }}{% endif %}</a></li>
+        <li aria-current="page">{{ breadcrumbs_action }}</li>
+    {% else %}
+        <li{% if not instance %} aria-current="page"{% endif %}>{% if folder.label %}{{ folder.label }}{% else %}{{ folder.name }}{% endif %}</li>
+        {% if instance %}
+            <li aria-current="page">{% if instance.label %}{{ instance.label }}{% else %}{{ instance.name }}{% endif %}</li>
+        {% endif %}
+    {% endif %}
+</ol>
+{% else %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}" title="{% translate 'Go back to admin homepage' %}">
+        {% translate "Home" %}
+    </a>
+    &rsaquo;
+    <a href="{% url 'admin:app_list' app_label='filer' %}" title="{% translate 'Go back to Filer app' %}">
+        {% translate "Filer" %}
+    </a>
+    &rsaquo; <a href="{% url 'admin:filer-directory_listing-root' %}{% filer_admin_context_url_params %}" title="{% translate 'Go back to root folder' %}">{% translate "Folder" %}</a>
+    {% for ancestor_folder in folder.logical_path %}
+        &rsaquo;
+        <a href="{{ ancestor_folder.get_admin_directory_listing_url_path }}{% filer_admin_context_url_params %}"
+            title="{% blocktrans with ancestor_folder.name as folder_name %}Go back to '{{ folder_name }}' folder{% endblocktrans %}">
+            {% if ancestor_folder.label %}{{ ancestor_folder.label }}{% else %}{{ ancestor_folder.name }}{% endif %}
+        </a>
+    {% endfor %}
+    &rsaquo; {% if folder.label %}{{ folder.label }}{% else %}{{ folder.name }}{% endif %}
+    {% if breadcrumbs_action %}
+        &rsaquo;
+        <a href="{{ folder.get_admin_directory_listing_url_path }}"
+            title="{% blocktrans with folder.name as folder_name %}Go back to '{{ folder_name }}' folder{% endblocktrans %}">
+            {% if folder.label %}
+                {{ folder.label }}
+            {% else %}
+                {{ folder.name }}
+            {% endif %}
+        </a>
+        &rsaquo;
+        {{ breadcrumbs_action }}
+    {% else %}
+        {% if not instance.is_root and instance.is_smart_folder %}
+            &rsaquo;
+        {% endif %}
+        {% if instance.label %}
+            {{ instance.label }}
+        {% else %}
+            {{ instance.name }}
+        {% endif %}
+    {% endif %}
+</div>
+{% endif %}

--- a/filer/templatetags/filer_admin_tags.py
+++ b/filer/templatetags/filer_admin_tags.py
@@ -1,6 +1,7 @@
 import logging
 from math import ceil
 
+from django import VERSION as DJANGO_VERSION
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.files.storage import FileSystemStorage
 from django.template import Library
@@ -75,6 +76,18 @@ def filer_folder_list_type_switcher(context):
 def filer_admin_context_url_params(context, first_separator='?'):
     return admin_url_params_encoded(
         context['request'], first_separator=first_separator)
+
+
+@register.simple_tag
+def django_version_gte(major, minor=0):
+    """Return ``True`` if the running Django version is at least ``(major, minor)``.
+
+    Used in the admin templates to switch between the legacy
+    ``<div class="breadcrumbs">`` markup (Django < 6.1) and the
+    ``<ol class="breadcrumbs">`` markup introduced in Django 6.1, whose CSS is
+    element-qualified (``ol.breadcrumbs``) and no longer styles a ``<div>``.
+    """
+    return DJANGO_VERSION[:2] >= (major, minor)
 
 
 @register.simple_tag(takes_context=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Framework :: Django CMS",
     "Framework :: Django CMS :: 3.11",
     "Framework :: Django CMS :: 4.0",

--- a/tests/requirements/django-6.1.txt
+++ b/tests/requirements/django-6.1.txt
@@ -1,0 +1,3 @@
+-r base.txt
+
+django>=6.1,<6.2

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -28,7 +28,11 @@ from filer.models.filemodels import File
 from filer.models.foldermodels import Folder, FolderPermission
 from filer.models.virtualitems import FolderRoot
 from filer.settings import DEFERRED_THUMBNAIL_SIZES, FILER_IMAGE_MODEL
-from filer.templatetags.filer_admin_tags import file_icon_url, get_aspect_ratio_and_download_url
+from filer.templatetags.filer_admin_tags import (
+    django_version_gte,
+    file_icon_url,
+    get_aspect_ratio_and_download_url,
+)
 from filer.thumbnail_processors import normalize_subject_location
 from filer.utils.loader import load_model
 from tests.helpers import SettingsOverride, create_folder_structure, create_image, create_superuser
@@ -2088,3 +2092,60 @@ class AdditionalAdminFormsTests(TestCase):
                 response,
                 '<div class="form-row flex-container form-multiline field-crop field-upscale">',
             )
+
+
+class BreadcrumbsTests(TestCase):
+    """Filer's admin templates must emit the breadcrumb markup the running Django styles.
+
+    Django 6.1 replaced ``<div class="breadcrumbs">`` with ``<ol class="breadcrumbs">``
+    and its CSS selectors are element-qualified, so a ``<div>`` renders unstyled (#1615).
+    """
+
+    def setUp(self):
+        self.superuser = create_superuser()
+        self.client.login(username='admin', password='secret')
+        self.folder = Folder.objects.create(name="Breadcrumb Folder")
+
+    def tearDown(self):
+        self.client.logout()
+
+    def assertBreadcrumbs(self, response):
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode("utf-8")
+        if DJANGO_VERSION < (6, 1):
+            self.assertIn('<div class="breadcrumbs">', content)
+            self.assertNotIn('<ol class="breadcrumbs">', content)
+        else:
+            self.assertIn('<ol class="breadcrumbs">', content)
+            self.assertNotIn('<div class="breadcrumbs">', content)
+            # Django 6.1 generates the separators from ``li::after``; emitting
+            # them as well would show doubled chevrons.
+            breadcrumbs = content.split('<ol class="breadcrumbs">')[1].split('</ol>')[0]
+            self.assertNotIn('&rsaquo;', breadcrumbs)
+            self.assertIn('aria-current="page"', breadcrumbs)
+
+    def test_directory_listing_breadcrumbs(self):
+        response = self.client.get(reverse("admin:filer-directory_listing", args=[self.folder.pk]))
+        self.assertBreadcrumbs(response)
+
+    def test_folder_change_form_breadcrumbs(self):
+        response = self.client.get(reverse("admin:filer_folder_change", args=[self.folder.pk]))
+        self.assertBreadcrumbs(response)
+
+    def test_file_change_form_breadcrumbs(self):
+        file_object = File.objects.create(
+            original_filename="breadcrumb.txt",
+            file=django.core.files.base.ContentFile(b"content", name="breadcrumb.txt"),
+            folder=self.folder,
+        )
+        response = self.client.get(reverse("admin:filer_file_change", args=[file_object.pk]))
+        self.assertBreadcrumbs(response)
+
+    def test_delete_confirmation_breadcrumbs(self):
+        response = self.client.get(reverse("admin:filer_folder_delete", args=[self.folder.pk]))
+        self.assertBreadcrumbs(response)
+
+    def test_django_version_gte(self):
+        self.assertTrue(django_version_gte(*DJANGO_VERSION[:2]))
+        self.assertTrue(django_version_gte(DJANGO_VERSION[0] - 1))
+        self.assertFalse(django_version_gte(DJANGO_VERSION[0] + 1))

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist =
     ruff
     docs
     frontend
-    py{310,311,312}-{dj42,dj50,dj51,dj52}-{swap,noswap}
-    py{312,313,312}-{djmain}-{swap,noswap}
+    py{310,311,312}-{dj42,dj51,dj52}-{swap,noswap}
+    py{312,313,314}-{dj60,dj61,djmain}-{swap,noswap}
 
 [gh-actions]
 python =
@@ -12,6 +12,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 skip_missing_interpreters=True
 
@@ -21,9 +22,10 @@ allowlist_externals =
     {envpython}
 deps =
     dj42: -r tests/requirements/django-4.2.txt
-    dj50: -r tests/requirements/django-5.0.txt
     dj51: -r tests/requirements/django-5.1.txt
     dj52: -r tests/requirements/django-5.2.txt
+    dj60: -r tests/requirements/django-6.0.txt
+    dj61: -r tests/requirements/django-6.1.txt
     djmain: -r tests/requirements/django-main.txt
 commands =
     {envpython} --version


### PR DESCRIPTION
## Summary by Sourcery

Support Django 6.1 while keeping admin breadcrumb rendering compatible across supported Django versions.

New Features:
- Add compatibility with Django 6.1, including the framework classifier and dependency configuration.

Bug Fixes:
- Ensure Filer admin breadcrumbs render with Django 6.1-compatible markup while preserving legacy markup on older Django versions.

Enhancements:
- Centralize admin breadcrumb rendering and add version-aware template support for directory, folder, file, and deletion views.

Build:
- Add Django 6.1 requirements and tox environments, including Python 3.14 coverage.

CI:
- Run the test matrix against Django 6.1 on Python 3.10 and 3.11.

Tests:
- Add coverage for breadcrumb markup across admin views and Django version detection.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #1584
* fixes #1615 

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [x] I have added or modified the tests when changing logic
* [x] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [x] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.

## Summary by Sourcery

Support Django 6.1 while maintaining compatible Filer admin breadcrumb rendering across supported Django versions.

New Features:
- Add Django 6.1 support across package metadata, dependency configurations, tox environments, and CI coverage.

Bug Fixes:
- Render Filer admin breadcrumbs with Django 6.1-compatible ordered-list markup while retaining legacy markup for older Django versions.

Enhancements:
- Centralize breadcrumb rendering for folder listings and add version-aware support across Filer admin views.

Build:
- Add Django 6.1 test requirements and tox coverage, including Python 3.14 environments.

CI:
- Run Django 6.1 tests on Python 3.10 and 3.11.

Tests:
- Add admin breadcrumb and Django version detection coverage across listing, change, and deletion views.

Chores:
- Update the pull request template to reference the current Discord review channel.