### PR TITLE
feat: Simplified SVG handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,3 +64,42 @@ jobs:
       run: coverage run ./tests/settings.py
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v6
+
+  unit-tests-without-svg-renderer:
+    # svglib and reportlab are the optional django-filer[svg] extra. The matrix
+    # above always has them, so this job covers what a plain "pip install
+    # django-filer" gets: filer reading and thumbnailing SVGs on its own.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.13'
+    - name: library prerequisites
+      run: |
+        sudo apt-get update
+        sudo apt-get install python-dev-is-python3 libpq-dev libmagic1 gcc libxml2-dev libxslt1-dev libjpeg62 libopenjp2-7 -y
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r tests/requirements/django-5.2.txt
+        pip install -e .
+    - name: Remove the optional SVG renderer
+      run: pip uninstall -y svglib reportlab
+    - name: Check that it is really gone
+      # Without this the job would silently degrade into a duplicate of the
+      # matrix above if anything ever pulls the renderer back in.
+      run: |
+        python - <<'EOF'
+        import importlib.util
+        import sys
+        still_here = [name for name in ('svglib', 'reportlab')
+                      if importlib.util.find_spec(name) is not None]
+        if still_here:
+            sys.exit(f"{', '.join(still_here)} still installed: this job tests nothing")
+        EOF
+    - name: Run coverage
+      run: coverage run ./tests/settings.py
+    - name: Upload Coverage to Codecov
+      uses: codecov/codecov-action@v6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,11 +5,31 @@ CHANGELOG
 3.6.0 (unreleased)
 ==================
 
+* feat: SVG support no longer requires an SVG renderer. filer reads an SVG's size
+  from the document and thumbnails it by rewriting ``width``, ``height`` and
+  ``viewBox`` on the root element, which keeps the vector data intact instead of
+  re-drawing it. ``easy-thumbnails[svg]`` - and with it svglib, reportlab and lxml,
+  around 14 MB - moved from a hard dependency to the new ``django-filer[svg]``
+  extra (#1547).
+* fix: SVG thumbnails without a ``viewBox`` were scaled by growing the canvas
+  rather than the drawing.
+* fix: When an image's dimensions could not be read, the file object was left at
+  its end, so upload validators that inspect the content saw an empty file.
 * feat: Add support for Django 6.1. The admin breadcrumbs now render as
   ``<ol class="breadcrumbs">`` on Django 6.1 and later, matching the markup its
   element-qualified CSS selectors expect, and keep the legacy
   ``<div class="breadcrumbs">`` markup on older versions.
 * ci: Test against Django 6.0 and 6.1.
+
+.. note::
+
+   Existing installations keep SVG support unchanged: upgrading does not always uninstall
+   svglib or reportlab. Fresh installs and re-locked dependency files no longer get
+   them. The only documents that still need them are those whose size cannot be read
+   from the markup, for example ``width="100%"`` without a ``viewBox``; install
+   ``django-filer[svg]`` if your project has such files. Thumbnails generated from
+   now on are the original document rescaled rather than a reportlab rendering of
+   it - existing cached thumbnails keep their file names and are still served.
 
 .. note::
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ CHANGELOG
   own height instead, which does not match how the image is drawn.
 * fix: When an image's dimensions could not be read, the file object was left at
   its end, so upload validators that inspect the content saw an empty file.
+* fix: SVG documents nesting elements more than
+  ``filer.utils.svg.MAX_NESTING_DEPTH`` (100) levels deep are refused. Writing
+  such a document out recurses once per level and would exhaust the stack while
+  a thumbnail is generated. Real documents nest a handful of levels.
 * feat: Add support for Django 6.1. The admin breadcrumbs now render as
   ``<ol class="breadcrumbs">`` on Django 6.1 and later, matching the markup its
   element-qualified CSS selectors expect, and keep the legacy

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,10 @@ CHANGELOG
   extra (#1547).
 * fix: SVG thumbnails without a ``viewBox`` were scaled by growing the canvas
   rather than the drawing.
+* fix: An SVG stating only one of ``width`` and ``height`` alongside a ``viewBox``
+  now keeps the dimension it states and derives the other from the viewBox's
+  aspect ratio, the way a browser sizes it. The renderer reported the viewBox's
+  own height instead, which does not match how the image is drawn.
 * fix: When an image's dimensions could not be read, the file object was left at
   its end, so upload validators that inspect the content saw an empty file.
 * feat: Add support for Django 6.1. The admin breadcrumbs now render as
@@ -30,6 +34,8 @@ CHANGELOG
    ``django-filer[svg]`` if your project has such files. Thumbnails generated from
    now on are the original document rescaled rather than a reportlab rendering of
    it - existing cached thumbnails keep their file names and are still served.
+   Installing the extra only ever adds documents filer can size; it never accepts
+   a document filer rejects, so it cannot weaken the SVG upload checks.
 
 .. note::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,6 +18,22 @@ retrieved from iOS devices by airdrop) using an optional dependency::
 
     $ pip install django-filer\[heif\]
 
+.. _optional_svg_support:
+
+Optional SVG renderer
+---------------------
+
+django-filer reads the size of an SVG and scales or crops it by rewriting the
+document itself, so SVG uploads and thumbnails work out of the box. Documents
+that state their size only in relative units (``width="100%"`` without a
+``viewBox``, say) cannot be measured that way. If you have such files, install
+the optional SVG renderer, which derives their size by drawing them::
+
+    $ pip install django-filer\[svg\]
+
+This pulls in `svglib`_ and `reportlab`_ through ``easy-thumbnails[svg]``.
+Before version 3.6, django-filer always installed them.
+
 
 Dependencies
 ------------
@@ -36,6 +52,11 @@ check `Pillow doc`_.
 If heif support is chosen, django-filer also installs
 
 * pillow-heif
+
+If the optional SVG renderer is chosen, django-filer also installs
+
+* svglib
+* reportlab
 
 
 Configuration
@@ -163,6 +184,8 @@ generation errors,  two options are provided to help when working with ``django-
 .. _Django: http://djangoproject.com
 .. _django-polymorphic: https://github.com/bconstantin/django_polymorphic
 .. _easy_thumbnails: https://github.com/SmileyChris/easy-thumbnails
+.. _svglib: https://github.com/deeplook/svglib
+.. _reportlab: https://www.reportlab.com/
 .. _sorl.thumbnail: http://thumbnail.sorl.net/
 .. _Pillow: http://pypi.python.org/pypi/Pillow/
 .. _Pillow doc: https://pillow.readthedocs.io/en/latest/installation.html

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -193,10 +193,15 @@ Defaults to ``MAX_IMAGE_PIXELS``. But when set, should always be lower than the 
 
 This is useful setting to prevent decompression bomb DOS attack.
 
-The limit applies to raster images. A vector image (SVG) is measured by the size
-it declares; one that declares no usable size is stored with unset dimensions and
-rendered with a generic icon in the admin, since it carries no pixel count that
-could be a decompression bomb.
+The limit applies to every image whose pixel size is known, a vector image (SVG)
+included: an SVG is measured by the size it declares, and is refused just like a
+raster image if that exceeds the limit.
+
+Images whose size cannot be read are treated differently by type. For a raster
+image that is itself the signature of a decompression bomb, because Pillow
+reports no size for one, so it is refused. A vector image has no pixel count to
+compare against, so it is stored with unset dimensions and rendered with a
+generic icon in the admin.
 
 
 ``FILER_ADD_FILE_VALIDATORS``

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -193,6 +193,11 @@ Defaults to ``MAX_IMAGE_PIXELS``. But when set, should always be lower than the 
 
 This is useful setting to prevent decompression bomb DOS attack.
 
+The limit applies to raster images. A vector image (SVG) is measured by the size
+it declares; one that declares no usable size is stored with unset dimensions and
+rendered with a generic icon in the admin, since it carries no pixel count that
+could be a decompression bomb.
+
 
 ``FILER_ADD_FILE_VALIDATORS``
 -----------------------------

--- a/docs/upgrading.rst
+++ b/docs/upgrading.rst
@@ -7,6 +7,34 @@ Usually upgrade procedure is straightforward: update the package and run migrati
 require special attention from the developer and here we provide upgrade instructions for such cases.
 
 
+from 3.x to 3.6
+---------------
+
+django-filer 3.6 no longer installs an SVG renderer. It reads an SVG's size from
+the document and thumbnails it by rewriting the root element, so svglib and
+reportlab (roughly 14 MB, pulled in through ``easy-thumbnails[svg]``) became the
+optional :ref:`optional_svg_support` extra.
+
+Upgrading an existing environment changes nothing: ``pip install -U django-filer``
+does not uninstall packages that are already there. Fresh installs and re-locked
+dependency files (``uv.lock``, ``poetry.lock``, ``pip-compile`` output) do drop
+them, and that is where you may notice a difference.
+
+Only documents whose size cannot be read from the markup still need the renderer,
+for example ``width="100%"`` without a ``viewBox``. Their dimensions stay unset
+and the admin shows a generic image icon instead of a preview. If your project has
+such files, install
+
+.. code-block:: shell
+
+    $ pip install django-filer\[svg\]
+
+SVG thumbnails generated from 3.6 on are the original document rescaled rather
+than a reportlab rendering of it, which preserves the vector data more faithfully.
+Thumbnail file names are unchanged, so thumbnails cached by earlier versions keep
+being served.
+
+
 from 3.x to 3.3
 ---------------
 

--- a/filer/management/commands/filer_check.py
+++ b/filer/management/commands/filer_check.py
@@ -154,8 +154,8 @@ class Command(BaseCommand):
         from django.db.models import Q
 
         import easy_thumbnails
-        from easy_thumbnails.VIL import Image as VILImage
 
+        from filer.utils import svg
         from filer.utils.compatibility import PILImage
 
         ImageModel = load_model(filer_settings.FILER_IMAGE_MODEL)
@@ -170,9 +170,10 @@ class Command(BaseCommand):
             except FileNotFoundError:
                 continue
             if image.file.name.lower().endswith('.svg'):
-                # For SVG files, use VILImage (invalid SVGs do not throw errors)
-                with VILImage.load(imgfile) as vil_image:
-                    image._width, image._height = vil_image.size
+                try:
+                    image._width, image._height = svg.get_dimensions(imgfile)
+                except ValueError:
+                    continue
             else:
                 try:
                     with PILImage.open(imgfile) as pil_image:

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -9,10 +9,10 @@ from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 import easy_thumbnails.utils
-from easy_thumbnails.VIL import Image as VILImage
 from PIL.Image import MAX_IMAGE_PIXELS
 
 from .. import settings as filer_settings
+from ..utils import svg
 from ..utils.compatibility import PILImage
 from ..utils.filer_easy_thumbnails import FilerThumbnailer
 from ..utils.pil_exif import get_exif_for_file
@@ -121,6 +121,7 @@ class BaseImage(File):
     def file_data_changed(self, post_init=False):
         attrs_updated = super().file_data_changed(post_init=post_init)
         if attrs_updated:
+            imgfile = None
             try:
                 try:
                     imgfile = self.file.file
@@ -128,19 +129,27 @@ class BaseImage(File):
                     imgfile = self.file_ptr.file
                 imgfile.seek(0)
                 if self.mime_type == 'image/svg+xml':
-                    self._width, self._height = VILImage.load(imgfile).size
+                    self._width, self._height = svg.get_dimensions(imgfile)
                     self._transparent = True
                 else:
                     pil_image = PILImage.open(imgfile)
                     self._width, self._height = pil_image.size
                     self._transparent = easy_thumbnails.utils.is_transparent(pil_image)
-                imgfile.seek(0)
             except Exception:
                 if post_init is False:
                     # in case `imgfile` could not be found, unset dimensions
                     # but only if not initialized by loading a fixture file
                     self._width, self._height = None, None
                     self._transparent = False
+            finally:
+                if imgfile is not None:
+                    # The upload validators read from the same file object, so
+                    # rewind even when reading the dimensions failed - they must
+                    # not be handed an exhausted stream.
+                    try:
+                        imgfile.seek(0)
+                    except Exception:
+                        pass
         return attrs_updated
 
     def clean(self):
@@ -152,6 +161,11 @@ class BaseImage(File):
             return
 
         if self._width is None or self._height is None:
+            if self.mime_type == 'image/svg+xml':
+                # A vector image whose size cannot be read is not a
+                # decompression bomb: there is no pixel count to limit. It is
+                # rendered with a generic icon in the admin instead.
+                return
             # If image size exceeds Pillow's max image size, Pillow will not return width or height
             pixels = 2 * FILER_MAX_IMAGE_PIXELS + 1
             aspect = 16 / 9

--- a/filer/models/abstract.py
+++ b/filer/models/abstract.py
@@ -148,8 +148,11 @@ class BaseImage(File):
                     # not be handed an exhausted stream.
                     try:
                         imgfile.seek(0)
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.debug(
+                            "Failed to rewind image file stream after metadata read.",
+                            exc_info=exc,
+                        )
         return attrs_updated
 
     def clean(self):

--- a/filer/utils/filer_easy_thumbnails.py
+++ b/filer/utils/filer_easy_thumbnails.py
@@ -4,7 +4,7 @@ from io import StringIO
 from django.core.files.base import ContentFile
 
 from easy_thumbnails import engine, utils
-from easy_thumbnails.exceptions import InvalidImageFormatError
+from easy_thumbnails.exceptions import EasyThumbnailsError, InvalidImageFormatError
 from easy_thumbnails.files import Thumbnailer, ThumbnailFile
 
 from . import svg
@@ -91,10 +91,14 @@ def svg_source_generator(source, **options):
     An easy-thumbnails source generator that opens an SVG with
     :mod:`filer.utils.svg` instead of ``easy_thumbnails.VIL``, so that
     thumbnailing an SVG needs no SVG renderer.
+
+    Documents that can only be measured by rendering them still go through the
+    renderer when the optional ``django-filer[svg]`` extra is installed, so that
+    they thumbnail as well as they report their size.
     """
     if not source:
         return None
-    return svg.load(source)
+    return svg.open_image(source)
 
 
 class SvgThumbnailFile(ThumbnailFile):
@@ -134,6 +138,7 @@ class SvgThumbnailerMixin:
                 silent_template_exception=silent_template_exception)
 
         thumbnail_options = self.get_options(thumbnail_options)
+        self._check_thumbnail_size(thumbnail_options['size'])
         image = engine.generate_source_image(
             self, thumbnail_options, [svg_source_generator],
             fail_silently=silent_template_exception)
@@ -157,6 +162,26 @@ class SvgThumbnailerMixin:
         thumbnail._committed = False
         thumbnail._dimensions_cache = thumbnail_image.size
         return thumbnail
+
+    @staticmethod
+    def _check_thumbnail_size(size):
+        """
+        Reject the sizes ``Thumbnailer.generate_thumbnail()`` rejects.
+
+        Its check runs before the branch this mixin replaces, so it has to be
+        repeated here: an SVG is happy to be written with a zero or negative
+        width, where PIL would refuse.
+        """
+        min_dim, max_dim = 0, 0
+        for dim in size:
+            try:
+                dim = float(dim)
+            except (TypeError, ValueError):
+                continue
+            min_dim, max_dim = min(min_dim, dim), max(max_dim, dim)
+        if max_dim == 0 or min_dim < 0:
+            raise EasyThumbnailsError(
+                "The source image has an invalid size ({0}x{1})".format(*size))
 
     def get_existing_thumbnail(self, thumbnail_options):
         thumbnail = super().get_existing_thumbnail(thumbnail_options)

--- a/filer/utils/filer_easy_thumbnails.py
+++ b/filer/utils/filer_easy_thumbnails.py
@@ -1,6 +1,13 @@
 import os
+from io import StringIO
 
-from easy_thumbnails.files import Thumbnailer
+from django.core.files.base import ContentFile
+
+from easy_thumbnails import engine, utils
+from easy_thumbnails.exceptions import InvalidImageFormatError
+from easy_thumbnails.files import Thumbnailer, ThumbnailFile
+
+from . import svg
 
 
 def thumbnail_to_original_filename(thumbnail_name):
@@ -79,11 +86,94 @@ class ActionThumbnailerMixin:
         return False
 
 
-class FilerThumbnailer(ThumbnailerNameMixin, Thumbnailer):
+def svg_source_generator(source, **options):
+    """
+    An easy-thumbnails source generator that opens an SVG with
+    :mod:`filer.utils.svg` instead of ``easy_thumbnails.VIL``, so that
+    thumbnailing an SVG needs no SVG renderer.
+    """
+    if not source:
+        return None
+    return svg.load(source)
+
+
+class SvgThumbnailFile(ThumbnailFile):
+    """
+    A ``ThumbnailFile`` that reads the dimensions of an SVG thumbnail from the
+    document itself. easy-thumbnails resolves them through
+    ``easy_thumbnails.VIL``, which requires svglib and reportlab.
+    """
+
+    def _get_image_dimensions(self):
+        if not hasattr(self, '_dimensions_cache'):
+            close = self.closed
+            self.open()
+            try:
+                self._dimensions_cache = svg.get_dimensions(self)
+            finally:
+                if close:
+                    self.close()
+        return self._dimensions_cache
+
+
+class SvgThumbnailerMixin:
+    """
+    Thumbnail SVG sources by rewriting the document instead of rendering it.
+
+    Scaling and cropping an SVG only means setting ``width``, ``height`` and
+    ``viewBox`` on the root element, which keeps the original vector data
+    intact. easy-thumbnails does the same thing, but reaches the root element
+    by parsing the file with svglib and re-drawing it onto a reportlab canvas
+    -- an optional dependency of filer since 3.6.
+    """
+
+    def generate_thumbnail(self, thumbnail_options, silent_template_exception=False):
+        if not svg.is_svg(self.name):
+            return super().generate_thumbnail(
+                thumbnail_options,
+                silent_template_exception=silent_template_exception)
+
+        thumbnail_options = self.get_options(thumbnail_options)
+        image = engine.generate_source_image(
+            self, thumbnail_options, [svg_source_generator],
+            fail_silently=silent_template_exception)
+        if image is None:
+            msg = "The source file does not appear to be an SVG image: '{name}'"
+            raise InvalidImageFormatError(msg.format(name=self.name))
+
+        thumbnail_image = engine.process_image(
+            image, thumbnail_options, self.thumbnail_processors)
+        filename = self.get_thumbnail_name(
+            thumbnail_options,
+            transparent=utils.is_transparent(thumbnail_image))
+
+        destination = StringIO()
+        thumbnail_image.save(destination, format='SVG')
+
+        thumbnail = SvgThumbnailFile(
+            filename, file=ContentFile(destination.getvalue().encode()),
+            storage=self.thumbnail_storage, thumbnail_options=thumbnail_options)
+        thumbnail.image = thumbnail_image
+        thumbnail._committed = False
+        thumbnail._dimensions_cache = thumbnail_image.size
+        return thumbnail
+
+    def get_existing_thumbnail(self, thumbnail_options):
+        thumbnail = super().get_existing_thumbnail(thumbnail_options)
+        if thumbnail is not None and svg.is_svg(thumbnail.name):
+            # easy-thumbnails builds the ``ThumbnailFile`` deep inside
+            # ``get_existing_thumbnail()`` and offers no hook for the class it
+            # uses. Re-tagging the instance is the least invasive way to give
+            # SVG thumbnails dimensions without svglib.
+            thumbnail.__class__ = SvgThumbnailFile
+        return thumbnail
+
+
+class FilerThumbnailer(SvgThumbnailerMixin, ThumbnailerNameMixin, Thumbnailer):
     def __init__(self, *args, **kwargs):
         self.thumbnail_basedir = kwargs.pop('thumbnail_basedir', '')
         super().__init__(*args, **kwargs)
 
 
-class FilerActionThumbnailer(ActionThumbnailerMixin, Thumbnailer):
+class FilerActionThumbnailer(SvgThumbnailerMixin, ActionThumbnailerMixin, Thumbnailer):
     pass

--- a/filer/utils/svg.py
+++ b/filer/utils/svg.py
@@ -45,6 +45,13 @@ _UNITS_IN_PX = {
 
 _LENGTH = re.compile(r'^([+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?)\s*([a-z%]*)$')
 
+# Deepest element nesting accepted. ``ElementTree`` serializes recursively, one
+# frame per level, so a deeply nested document exhausts the interpreter's stack
+# while a thumbnail is being written -- inside a request, where much of that
+# stack is already spent. A few kilobytes of nested <g> elements are enough.
+# Real documents are nowhere near this: filer's own icons nest five levels deep.
+MAX_NESTING_DEPTH = 100
+
 
 class UnresolvableSize(ValueError):
     """
@@ -106,6 +113,22 @@ def reject_entity_declarations(content):
         # Malformed: leave the reporting to the parse below, which has the
         # better error message.
         pass
+
+
+def _exceeds_nesting_depth(root, limit=MAX_NESTING_DEPTH):
+    """
+    Return whether ``root`` nests deeper than ``limit``.
+
+    Walked iteratively: measuring the tree must not be able to blow the very
+    stack the limit exists to protect.
+    """
+    stack = [(root, 1)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > limit:
+            return True
+        stack.extend((child, depth + 1) for child in node)
+    return False
 
 
 def is_svg(name):
@@ -335,6 +358,10 @@ def load(fp):
         raise ValueError(f"Cannot parse SVG document: {error}") from error
     if root.tag not in ('svg', f'{{{SVG_NAMESPACE}}}svg'):
         raise ValueError(f"Root element is <{root.tag}>, not <svg>")
+    if _exceeds_nesting_depth(root):
+        raise ValueError(
+            f"SVG document nests elements more than {MAX_NESTING_DEPTH} levels deep"
+        )
     return SvgImage(root)
 
 

--- a/filer/utils/svg.py
+++ b/filer/utils/svg.py
@@ -1,0 +1,283 @@
+"""
+Dependency-free handling of the SVG geometry filer needs.
+
+filer only ever asks three things of an SVG: how big it is, a scaled copy and a
+cropped copy. All three are attribute changes on the root ``<svg>`` element, so
+they need an XML parser rather than an SVG renderer.
+
+``easy_thumbnails.VIL`` answers the same questions by parsing the document with
+svglib and re-rendering it through reportlab, which is why
+``easy-thumbnails[svg]`` used to be a hard requirement of filer. It is optional
+now: it is only consulted as a fallback for documents whose size cannot be read
+from the markup itself.
+"""
+
+import os
+import re
+import xml.etree.ElementTree as ET
+from copy import deepcopy
+from pathlib import Path
+
+
+SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
+XLINK_NAMESPACE = 'http://www.w3.org/1999/xlink'
+
+# Serialize with the customary prefixes instead of ET's generated "ns0:" ones.
+# The namespace URI is what matters, but renderers have been known to key on the
+# literal ``xlink:`` prefix.
+ET.register_namespace('', SVG_NAMESPACE)
+ET.register_namespace('xlink', XLINK_NAMESPACE)
+
+# CSS absolute length units expressed in pixels.
+# See https://www.w3.org/TR/css-values-3/#absolute-lengths
+_UNITS_IN_PX = {
+    '': 1.0,
+    'px': 1.0,
+    'pt': 96 / 72,
+    'pc': 16.0,
+    'in': 96.0,
+    'cm': 96 / 2.54,
+    'mm': 96 / 25.4,
+    'q': 96 / 101.6,
+}
+
+_LENGTH = re.compile(r'^([+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?)\s*([a-z%]*)$')
+
+# The internal subset of a DTD is the only place where entity declarations can
+# appear. ``xml.etree`` expands them, which makes "billion laughs" expansion
+# possible, so documents carrying them are rejected. External entities are not
+# a concern: expat does not resolve them and reports an undefined entity.
+_INTERNAL_SUBSET = re.compile(rb'<!DOCTYPE[^>\[]*\[(.*?)\]', re.DOTALL)
+
+
+def is_svg(name):
+    """Return whether ``name`` looks like the file name of an SVG image."""
+    return os.path.splitext(name or '')[1][1:].lower() == 'svg'
+
+
+def parse_length(value):
+    """
+    Return ``value`` converted to pixels, or ``None`` if it is not an absolute
+    length. Relative units (``%``, ``em``, ``ex``, ...) cannot be resolved
+    without a rendering context; the ``viewBox`` is the better source then.
+    """
+    if not value:
+        return None
+    match = _LENGTH.match(value.strip())
+    if not match:
+        return None
+    number, unit = match.groups()
+    try:
+        factor = _UNITS_IN_PX[unit.lower()]
+    except KeyError:
+        return None
+    return float(number) * factor
+
+
+def parse_viewbox(value):
+    """
+    Return the ``viewBox`` attribute as an ``(x, y, width, height)`` tuple of
+    user units, or ``None`` if it is missing or unusable.
+    """
+    if not value:
+        return None
+    parts = re.split(r'[\s,]+', value.strip())
+    if len(parts) != 4:
+        return None
+    try:
+        x, y, width, height = (float(part) for part in parts)
+    except ValueError:
+        return None
+    if width <= 0 or height <= 0:
+        return None
+    return x, y, width, height
+
+
+def _format(number):
+    """Render a float the way SVG attributes want it: short, without an exponent."""
+    return f'{number:.6f}'.rstrip('0').rstrip('.') or '0'
+
+
+class SvgImage:
+    """
+    A minimal, PIL-compatible view on an SVG document.
+
+    It mirrors the subset of ``PIL.Image.Image`` that easy-thumbnails'
+    processors use -- and the interface of ``easy_thumbnails.VIL.Image.Image``
+    -- so SVG sources can travel through the regular thumbnail pipeline.
+    """
+
+    # SVG has no color mode; ``None`` is what VIL reports too.
+    mode = None
+
+    def __init__(self, root):
+        self.root = root
+        viewbox = parse_viewbox(root.get('viewBox'))
+        width = parse_length(root.get('width'))
+        height = parse_length(root.get('height'))
+        if width is None or height is None:
+            if viewbox is None:
+                raise ValueError(
+                    "SVG document declares neither an absolute width and height nor a viewBox"
+                )
+            width, height = viewbox[2], viewbox[3]
+        if viewbox is None:
+            # Without a viewBox, changing width and height resizes the canvas
+            # but not its contents. Fall back to the implied one.
+            viewbox = (0.0, 0.0, width, height)
+        self.width = float(width)
+        self.height = float(height)
+        self.viewbox = viewbox
+
+    @property
+    def size(self):
+        return self.width, self.height
+
+    def getbbox(self):
+        """
+        Return the bounding box as a 4-tuple of the left, upper, right and
+        lower pixel coordinate.
+        """
+        return 0.0, 0.0, self.width, self.height
+
+    def resize(self, size, **kwargs):
+        """Return a copy scaled to ``size``, a ``(width, height)`` 2-tuple."""
+        width, height = (float(value) for value in size)
+        copy = SvgImage(deepcopy(self.root))
+        copy._set_geometry(width, height, self.viewbox)
+        return copy
+
+    def crop(self, box=None):
+        """
+        Return a rectangular region of this image as a copy.
+
+        ``box`` is a ``(left, upper, right, lower)`` 4-tuple in pixels, which
+        is mapped onto the user coordinate system of the current ``viewBox``.
+        """
+        copy = SvgImage(deepcopy(self.root))
+        if not box:
+            return copy
+        left, upper, right, lower = (float(value) for value in box)
+        width, height = right - left, lower - upper
+        if width <= 0 or height <= 0:
+            return copy
+        view_x, view_y, view_width, view_height = self.viewbox
+        scale_x = view_width / self.width if self.width else 1.0
+        scale_y = view_height / self.height if self.height else 1.0
+        copy._set_geometry(width, height, (
+            view_x + left * scale_x,
+            view_y + upper * scale_y,
+            width * scale_x,
+            height * scale_y,
+        ))
+        return copy
+
+    def convert(self, *args, **kwargs):
+        """Does nothing, just for compatibility with PIL."""
+        return self
+
+    def filter(self, *args, **kwargs):
+        """Does nothing, just for compatibility with PIL."""
+        return self
+
+    def save(self, fp, format=None, **params):
+        """
+        Write the document to ``fp``, which may be a file name, a
+        ``pathlib.Path`` or a file object opened in text mode.
+
+        :exception ValueError: If ``format`` is given and is not ``'SVG'``.
+        """
+        if format is not None and format != 'SVG':
+            raise ValueError("Image format is expected to be 'SVG'")
+        data = ET.tostring(self.root, encoding='unicode')
+        if isinstance(fp, (str, Path)):
+            with open(fp, 'w') as handle:
+                handle.write(data)
+        else:
+            fp.write(data)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    def _set_geometry(self, width, height, viewbox):
+        self.width, self.height, self.viewbox = width, height, viewbox
+        self.root.set('width', _format(width))
+        self.root.set('height', _format(height))
+        self.root.set('viewBox', ' '.join(_format(value) for value in viewbox))
+
+
+def load(fp):
+    """
+    Return an :class:`SvgImage` for ``fp``, which may be a file name, a
+    ``pathlib.Path``, a Django ``File`` or any object with a ``read()`` method.
+
+    :exception ValueError: If the document is not parseable SVG or does not
+        declare a size.
+    """
+    if hasattr(fp, 'read'):
+        if hasattr(fp, 'seek'):
+            try:
+                fp.seek(0)
+            except (OSError, ValueError):
+                pass
+        content = fp.read()
+    else:
+        with open(fp, 'rb') as handle:
+            content = handle.read()
+    if isinstance(content, str):
+        content = content.encode()
+
+    subset = _INTERNAL_SUBSET.search(content)
+    if subset and b'<!ENTITY' in subset.group(1):
+        raise ValueError("SVG documents declaring XML entities are not supported")
+
+    try:
+        root = ET.fromstring(content)
+    except ET.ParseError as error:
+        raise ValueError(f"Cannot parse SVG document: {error}") from error
+    if root.tag not in ('svg', f'{{{SVG_NAMESPACE}}}svg'):
+        raise ValueError(f"Root element is <{root.tag}>, not <svg>")
+    return SvgImage(root)
+
+
+def _load_with_vil(fp):
+    """
+    Load ``fp`` through ``easy_thumbnails.VIL``, which renders the document
+    with svglib and reportlab. Returns ``None`` if the optional dependency is
+    not installed or cannot make sense of the file either.
+    """
+    try:
+        from easy_thumbnails.VIL import Image as VILImage
+    except ImportError:
+        return None
+    if hasattr(fp, 'seek'):
+        try:
+            fp.seek(0)
+        except (OSError, ValueError):
+            pass
+    try:
+        return VILImage.load(fp)
+    except Exception:
+        return None
+
+
+def get_dimensions(fp):
+    """
+    Return the ``(width, height)`` of an SVG document in pixels.
+
+    Documents that do not state their size in absolute units fall back to
+    ``easy_thumbnails.VIL`` (``pip install django-filer[svg]``), which can
+    derive it by rendering the whole drawing.
+
+    :exception ValueError: If the size cannot be determined at all.
+    """
+    try:
+        return load(fp).size
+    except ValueError:
+        image = _load_with_vil(fp)
+        if image is None:
+            raise
+        return image.size

--- a/filer/utils/svg.py
+++ b/filer/utils/svg.py
@@ -195,6 +195,13 @@ class SvgImage:
         viewbox = parse_viewbox(root.get('viewBox'))
         width, width_invalid = _dimension(root.get('width'))
         height, height_invalid = _dimension(root.get('height'))
+        if width_invalid or height_invalid:
+            # A stated but impossible size is broken markup. The viewBox must
+            # not paper over it: the document is saying something wrong, which
+            # is different from leaving the size for someone else to work out.
+            raise ValueError(
+                "SVG document declares a width or height that is not a positive length"
+            )
         if viewbox is not None:
             # A viewBox states both a size and an aspect ratio, so a dimension
             # the markup does state is kept and only the missing one is derived
@@ -206,10 +213,6 @@ class SvgImage:
             elif height is None:
                 height = width * viewbox[3] / viewbox[2]
         if width is None or height is None:
-            if width_invalid or height_invalid:
-                raise ValueError(
-                    "SVG document declares a width or height that is not a positive length"
-                )
             raise UnresolvableSize(
                 "SVG document states no absolute width and height and has no viewBox"
             )
@@ -353,9 +356,20 @@ def _load_with_vil(fp):
             # Continue and let VIL try to load from the current stream position.
             pass
     try:
-        return VILImage.load(fp)
+        image = VILImage.load(fp)
     except Exception:
         return None
+    if image is None:
+        return None
+    try:
+        width, height = (float(value) for value in image.size)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(width) or not math.isfinite(height) or width <= 0 or height <= 0:
+        # The renderer reports a zero or partial size for documents it cannot
+        # size either, which is no more usable than no answer at all.
+        return None
+    return image
 
 
 def open_image(fp):

--- a/filer/utils/svg.py
+++ b/filer/utils/svg.py
@@ -86,7 +86,8 @@ def reject_entity_declarations(content):
     except _EntityDeclaration:
         raise ValueError("SVG documents declaring XML entities are not supported") from None
     except _PrologParsed:
-        pass
+        # Expected sentinel exception used to stop parsing after the prolog.
+        return
     except expat.ExpatError:
         # Malformed: leave the reporting to the parse below, which has the
         # better error message.
@@ -272,7 +273,9 @@ def load(fp):
             try:
                 fp.seek(0)
             except (OSError, ValueError):
-                pass
+                # Some file-like objects are not seekable; continue reading
+                # from the current position to preserve compatibility.
+                _ = None
         content = fp.read()
     else:
         with open(fp, 'rb') as handle:
@@ -305,6 +308,8 @@ def _load_with_vil(fp):
         try:
             fp.seek(0)
         except (OSError, ValueError):
+            # Best-effort rewind only; some file-like objects are not seekable.
+            # Continue and let VIL try to load from the current stream position.
             pass
     try:
         return VILImage.load(fp)

--- a/filer/utils/svg.py
+++ b/filer/utils/svg.py
@@ -46,6 +46,20 @@ _UNITS_IN_PX = {
 _LENGTH = re.compile(r'^([+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?)\s*([a-z%]*)$')
 
 
+class UnresolvableSize(ValueError):
+    """
+    Raised when a well-formed SVG states no size that can be worked out from the
+    markup: a missing or relative width and height, and no viewBox to take the
+    size or the aspect ratio from.
+
+    It is the only failure the optional renderer can do anything about, so it is
+    the only one :func:`open_image` falls back on. Everything else -- a document
+    declaring entities, a root element that is not ``<svg>``, markup that does
+    not parse, a width that is not a positive length -- stays rejected whether
+    the renderer is installed or not.
+    """
+
+
 class _EntityDeclaration(Exception):
     """Raised out of the expat handler when the document declares an entity."""
 
@@ -99,25 +113,42 @@ def is_svg(name):
     return os.path.splitext(name or '')[1][1:].lower() == 'svg'
 
 
-def parse_length(value):
+def _dimension(value):
     """
-    Return ``value`` converted to pixels, or ``None`` if it is not an absolute
-    length. Relative units (``%``, ``em``, ``ex``, ...) cannot be resolved
-    without a rendering context; the ``viewBox`` is the better source then.
+    Return ``(length, invalid)`` for a ``width`` or ``height`` attribute.
+
+    ``length`` is the value in pixels, or ``None`` when the attribute does not
+    yield one. ``invalid`` tells the two reasons for that apart: markup that is
+    simply wrong -- a negative, zero or overflowing length -- as opposed to a
+    size that is merely not stated in absolute units, which a renderer could
+    still work out.
     """
-    if not value:
-        return None
+    if not value or not value.strip():
+        # An absent width or height defaults to 100% of the viewport.
+        return None, False
     match = _LENGTH.match(value.strip())
     if not match:
-        return None
+        return None, False
     number, unit = match.groups()
-    try:
-        factor = _UNITS_IN_PX[unit.lower()]
-    except KeyError:
-        return None
+    factor = _UNITS_IN_PX.get(unit.lower())
+    if factor is None:
+        # A relative unit (%, em, ex, ...) has no meaning without a context.
+        return None, False
     length = float(number) * factor
     # "1e999" parses as infinity, which overflows as soon as it is used.
-    return length if math.isfinite(length) else None
+    if not math.isfinite(length) or length <= 0:
+        return None, True
+    return length, False
+
+
+def parse_length(value):
+    """
+    Return ``value`` converted to pixels, or ``None`` if it is not a usable
+    absolute length. Relative units (``%``, ``em``, ``ex``, ...) cannot be
+    resolved without a rendering context, and a width or height has to be a
+    positive, finite number to be a size at all.
+    """
+    return _dimension(value)[0]
 
 
 def parse_viewbox(value):
@@ -162,16 +193,26 @@ class SvgImage:
     def __init__(self, root):
         self.root = root
         viewbox = parse_viewbox(root.get('viewBox'))
-        width = parse_length(root.get('width'))
-        height = parse_length(root.get('height'))
-        if width is None or height is None or width <= 0 or height <= 0:
-            # A size that is missing, relative or not a positive length at all
-            # leaves the viewBox as the only thing left to measure.
-            if viewbox is None:
+        width, width_invalid = _dimension(root.get('width'))
+        height, height_invalid = _dimension(root.get('height'))
+        if viewbox is not None:
+            # A viewBox states both a size and an aspect ratio, so a dimension
+            # the markup does state is kept and only the missing one is derived
+            # from the ratio -- the way a browser sizes an SVG.
+            if width is None and height is None:
+                width, height = viewbox[2], viewbox[3]
+            elif width is None:
+                width = height * viewbox[2] / viewbox[3]
+            elif height is None:
+                height = width * viewbox[3] / viewbox[2]
+        if width is None or height is None:
+            if width_invalid or height_invalid:
                 raise ValueError(
-                    "SVG document declares no usable width and height and no viewBox"
+                    "SVG document declares a width or height that is not a positive length"
                 )
-            width, height = viewbox[2], viewbox[3]
+            raise UnresolvableSize(
+                "SVG document states no absolute width and height and has no viewBox"
+            )
         if viewbox is None:
             # Without a viewBox, changing width and height resizes the canvas
             # but not its contents. Fall back to the implied one.
@@ -325,13 +366,15 @@ def open_image(fp):
     The two share the interface the thumbnail pipeline needs.
 
     The renderer is the optional ``django-filer[svg]`` extra; without it such a
-    document cannot be measured at all.
+    document cannot be measured at all. It is only asked about
+    :class:`UnresolvableSize`: a document filer rejects stays rejected either
+    way, so installing the extra can never weaken a check.
 
     :exception ValueError: If no image can be opened.
     """
     try:
         return load(fp)
-    except ValueError:
+    except UnresolvableSize:
         image = _load_with_vil(fp)
         if image is None:
             raise

--- a/filer/utils/svg.py
+++ b/filer/utils/svg.py
@@ -12,11 +12,13 @@ now: it is only consulted as a fallback for documents whose size cannot be read
 from the markup itself.
 """
 
+import math
 import os
 import re
 import xml.etree.ElementTree as ET
 from copy import deepcopy
 from pathlib import Path
+from xml.parsers import expat
 
 
 SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
@@ -43,11 +45,52 @@ _UNITS_IN_PX = {
 
 _LENGTH = re.compile(r'^([+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?)\s*([a-z%]*)$')
 
-# The internal subset of a DTD is the only place where entity declarations can
-# appear. ``xml.etree`` expands them, which makes "billion laughs" expansion
-# possible, so documents carrying them are rejected. External entities are not
-# a concern: expat does not resolve them and reports an undefined entity.
-_INTERNAL_SUBSET = re.compile(rb'<!DOCTYPE[^>\[]*\[(.*?)\]', re.DOTALL)
+
+class _EntityDeclaration(Exception):
+    """Raised out of the expat handler when the document declares an entity."""
+
+
+class _PrologParsed(Exception):
+    """Raised out of the expat handler once the root element starts."""
+
+
+def reject_entity_declarations(content):
+    """
+    Refuse documents that declare XML entities.
+
+    ``xml.etree`` expands internal entities, so a handful of nested declarations
+    expand to gigabytes ("billion laughs"). Entities can only be declared in a
+    DTD, which expat reports before the root element starts, so this reads no
+    further than the prolog. Letting expat do it rather than matching the markup
+    means comments, quoting and the document's encoding are all handled by the
+    same parser that will parse it for real.
+
+    External entities need no handling: expat does not resolve them and does not
+    fetch external DTD subsets, it reports an undefined entity instead.
+
+    :exception ValueError: If the document declares an entity.
+    """
+    parser = expat.ParserCreate()
+
+    def entity_declared(*args, **kwargs):
+        raise _EntityDeclaration
+
+    def root_element_started(*args, **kwargs):
+        raise _PrologParsed
+
+    parser.EntityDeclHandler = entity_declared
+    parser.UnparsedEntityDeclHandler = entity_declared
+    parser.StartElementHandler = root_element_started
+    try:
+        parser.Parse(content, True)
+    except _EntityDeclaration:
+        raise ValueError("SVG documents declaring XML entities are not supported") from None
+    except _PrologParsed:
+        pass
+    except expat.ExpatError:
+        # Malformed: leave the reporting to the parse below, which has the
+        # better error message.
+        pass
 
 
 def is_svg(name):
@@ -71,7 +114,9 @@ def parse_length(value):
         factor = _UNITS_IN_PX[unit.lower()]
     except KeyError:
         return None
-    return float(number) * factor
+    length = float(number) * factor
+    # "1e999" parses as infinity, which overflows as soon as it is used.
+    return length if math.isfinite(length) else None
 
 
 def parse_viewbox(value):
@@ -87,6 +132,9 @@ def parse_viewbox(value):
     try:
         x, y, width, height = (float(part) for part in parts)
     except ValueError:
+        return None
+    # float() happily accepts "nan" and "inf", which are not coordinates.
+    if not all(math.isfinite(value) for value in (x, y, width, height)):
         return None
     if width <= 0 or height <= 0:
         return None
@@ -115,10 +163,12 @@ class SvgImage:
         viewbox = parse_viewbox(root.get('viewBox'))
         width = parse_length(root.get('width'))
         height = parse_length(root.get('height'))
-        if width is None or height is None:
+        if width is None or height is None or width <= 0 or height <= 0:
+            # A size that is missing, relative or not a positive length at all
+            # leaves the viewBox as the only thing left to measure.
             if viewbox is None:
                 raise ValueError(
-                    "SVG document declares neither an absolute width and height nor a viewBox"
+                    "SVG document declares no usable width and height and no viewBox"
                 )
             width, height = viewbox[2], viewbox[3]
         if viewbox is None:
@@ -230,9 +280,7 @@ def load(fp):
     if isinstance(content, str):
         content = content.encode()
 
-    subset = _INTERNAL_SUBSET.search(content)
-    if subset and b'<!ENTITY' in subset.group(1):
-        raise ValueError("SVG documents declaring XML entities are not supported")
+    reject_entity_declarations(content)
 
     try:
         root = ET.fromstring(content)
@@ -264,20 +312,31 @@ def _load_with_vil(fp):
         return None
 
 
-def get_dimensions(fp):
+def open_image(fp):
     """
-    Return the ``(width, height)`` of an SVG document in pixels.
+    Return an image for ``fp``: an :class:`SvgImage`, or a
+    ``easy_thumbnails.VIL`` one for documents that do not state their size in
+    absolute units and can only be measured by rendering the whole drawing.
+    The two share the interface the thumbnail pipeline needs.
 
-    Documents that do not state their size in absolute units fall back to
-    ``easy_thumbnails.VIL`` (``pip install django-filer[svg]``), which can
-    derive it by rendering the whole drawing.
+    The renderer is the optional ``django-filer[svg]`` extra; without it such a
+    document cannot be measured at all.
 
-    :exception ValueError: If the size cannot be determined at all.
+    :exception ValueError: If no image can be opened.
     """
     try:
-        return load(fp).size
+        return load(fp)
     except ValueError:
         image = _load_with_vil(fp)
         if image is None:
             raise
-        return image.size
+        return image
+
+
+def get_dimensions(fp):
+    """
+    Return the ``(width, height)`` of an SVG document in pixels.
+
+    :exception ValueError: If the size cannot be determined.
+    """
+    return open_image(fp).size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires-python = ">=3.8"
 dependencies = [
     "django>=3.2",
     "django-polymorphic<5.0",
-    "easy-thumbnails[svg]",
+    "easy-thumbnails",
     "py-svg-hush",
 ]
 classifiers = [
@@ -56,6 +56,10 @@ classifiers = [
 
 [project.optional-dependencies]
 heif = ["pillow-heif"]
+# filer handles SVG images itself; this extra only adds easy-thumbnails'
+# svglib-based renderer as a fallback for documents that do not state their
+# size in absolute units.
+svg = ["easy-thumbnails[svg]"]
 
 [project.urls]
 Homepage = "https://github.com/django-cms/django-filer"

--- a/tests/requirements/base.txt
+++ b/tests/requirements/base.txt
@@ -2,6 +2,9 @@
 Pillow
 pillow-heif
 django-app-helper>=3.3.1
+# Optional: the SVG renderer behind the django-filer[svg] extra. The test suite
+# passes without it too; OptionalDependencyTests guards that it stays optional.
+easy-thumbnails[svg]
 
 # other requirements
 coverage

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -332,7 +332,10 @@ class SvgThumbnailTests(TestCase):
                     b'<rect width="5" height="5"/></svg>',
             name='relative.svg',
         )
-        self.assertEqual((image.width, image.height), (100.0, 100.0))
+        # What the renderer makes of "100%" is its business and varies by
+        # version; that it yields a usable size at all is filer's.
+        self.assertGreater(image.width, 0)
+        self.assertGreater(image.height, 0)
         thumbnail = get_thumbnailer(image).get_thumbnail({'size': (50, 50)})
         self.assertTrue(thumbnail.name.endswith('.svg'))
         self.assertEqual(ET.fromstring(self.read(thumbnail)).tag,

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -2,12 +2,15 @@
 
 import ast
 import pathlib
+import unittest
 import xml.etree.ElementTree as ET
 from io import BytesIO, StringIO
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
+from easy_thumbnails import VIL
+from easy_thumbnails.exceptions import EasyThumbnailsError
 from easy_thumbnails.files import get_thumbnailer
 
 from filer.settings import FILER_IMAGE_MODEL
@@ -48,6 +51,11 @@ class ParseLengthTests(TestCase):
         for value in ('100%', '2em', '3ex', '', None, 'auto'):
             self.assertIsNone(svg.parse_length(value), value)
 
+    def test_non_finite_lengths_are_rejected(self):
+        """``float()`` turns an overflowing exponent into infinity."""
+        for value in ('1e999', '-1e999', '1e999pt'):
+            self.assertIsNone(svg.parse_length(value), value)
+
 
 class ParseViewBoxTests(TestCase):
     def test_separators(self):
@@ -57,6 +65,11 @@ class ParseViewBoxTests(TestCase):
 
     def test_unusable(self):
         for value in ('', None, '0 0 10', '0 0 a b', '0 0 0 10', '0 0 10 -3'):
+            self.assertIsNone(svg.parse_viewbox(value), value)
+
+    def test_non_finite_coordinates_are_rejected(self):
+        """``float()`` accepts "nan" and "inf", which are not coordinates."""
+        for value in ('nan 0 10 10', '0 inf 10 10', '0 0 1e999 10', '0 0 10 -inf'):
             self.assertIsNone(svg.parse_viewbox(value), value)
 
 
@@ -99,6 +112,59 @@ class LoadTests(TestCase):
         )
         with self.assertRaises(ValueError):
             svg.load(BytesIO(bomb))
+
+    def test_entity_declaration_hidden_in_a_comment_is_rejected(self):
+        """A ``]`` inside a DTD comment must not be taken for the subset's end."""
+        bomb = (
+            b'<!DOCTYPE svg [<!-- ] --><!ENTITY a "aaaaaaaaaa">'
+            b'<!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">]>'
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+            b'<desc>&b;</desc></svg>'
+        )
+        with self.assertRaises(ValueError):
+            svg.load(BytesIO(bomb))
+
+    def test_entity_declaration_after_a_quoted_bracket_is_rejected(self):
+        bomb = (
+            b'<!DOCTYPE svg SYSTEM "a]b" [<!ENTITY a "aaaaaaaaaa">]>'
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+            b'<desc>&a;</desc></svg>'
+        )
+        with self.assertRaises(ValueError):
+            svg.load(BytesIO(bomb))
+
+    def test_entity_declaration_in_another_encoding_is_rejected(self):
+        """The check has to see the document the way the parser will."""
+        bomb = (
+            '<?xml version="1.0" encoding="UTF-16"?>'
+            '<!DOCTYPE svg [<!ENTITY a "aaaaaaaaaa">]>'
+            '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+            '<desc>&a;</desc></svg>'
+        ).encode('utf-16')
+        with self.assertRaises(ValueError):
+            svg.load(BytesIO(bomb))
+
+    def test_byte_order_mark_does_not_hide_an_entity_declaration(self):
+        bomb = (
+            b'\xef\xbb\xbf<!DOCTYPE svg [<!ENTITY a "aaaaaaaaaa">]>'
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+            b'<desc>&a;</desc></svg>'
+        )
+        with self.assertRaises(ValueError):
+            svg.load(BytesIO(bomb))
+
+    def test_non_positive_size_falls_back_to_the_viewbox(self):
+        image = svg.load(BytesIO(make_svg(width='0', height='0', viewBox='0 0 8 4')))
+        self.assertEqual(image.size, (8.0, 4.0))
+
+    def test_non_positive_size_without_a_viewbox_is_an_error(self):
+        for attrs in ({'width': '0', 'height': '0'}, {'width': '-10', 'height': '-5'}):
+            with self.assertRaises(ValueError):
+                svg.load(BytesIO(make_svg(**attrs)))
+
+    def test_infinite_size_is_an_error(self):
+        with self.assertRaises(ValueError):
+            svg.load(BytesIO(make_svg(width='1e999', height='10')))
 
     def test_external_doctype_is_accepted(self):
         """The DTD reference that many authoring tools emit is harmless."""
@@ -247,6 +313,30 @@ class SvgThumbnailTests(TestCase):
         existing = thumbnailer.get_existing_thumbnail(options)
         self.assertIsNotNone(existing)
         self.assertEqual((existing.width, existing.height), (100.0, 50.0))
+
+    def test_invalid_thumbnail_sizes_are_rejected(self):
+        """An SVG is happy to be written at any size, where PIL would refuse."""
+        thumbnailer = get_thumbnailer(self.create_image())
+        for size in ((0, 0), (-100, 100)):
+            with self.assertRaises(EasyThumbnailsError):
+                thumbnailer.get_thumbnail({'size': size})
+
+    @unittest.skipUnless(VIL.is_available(), "requires the django-filer[svg] extra")
+    def test_relative_size_thumbnails_with_the_optional_renderer(self):
+        """
+        A document that only the renderer can measure has to thumbnail as well
+        as it reports its size - the installation docs promise as much.
+        """
+        image = self.create_image(
+            content=b'<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">'
+                    b'<rect width="5" height="5"/></svg>',
+            name='relative.svg',
+        )
+        self.assertEqual((image.width, image.height), (100.0, 100.0))
+        thumbnail = get_thumbnailer(image).get_thumbnail({'size': (50, 50)})
+        self.assertTrue(thumbnail.name.endswith('.svg'))
+        self.assertEqual(ET.fromstring(self.read(thumbnail)).tag,
+                         '{http://www.w3.org/2000/svg}svg')
 
     def test_unreadable_svg_leaves_dimensions_unset(self):
         image = self.create_image(content=b'<svg><rect></svg>', name='broken.svg')

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -1,0 +1,285 @@
+"""Tests for filer.utils.svg and SVG thumbnailing without an SVG renderer."""
+
+import ast
+import pathlib
+import xml.etree.ElementTree as ET
+from io import BytesIO, StringIO
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from easy_thumbnails.files import get_thumbnailer
+
+from filer.models.imagemodels import Image
+from filer.utils import svg
+
+
+SVG_TEMPLATE = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    '<svg xmlns="http://www.w3.org/2000/svg" {attrs}>'
+    '<rect x="0" y="0" width="10" height="10" fill="red"/>'
+    '</svg>'
+)
+
+
+def make_svg(**attrs):
+    return SVG_TEMPLATE.format(
+        attrs=' '.join(f'{key.replace("_", "")}="{value}"' for key, value in attrs.items())
+    ).encode()
+
+
+class ParseLengthTests(TestCase):
+    def test_unitless_and_px(self):
+        self.assertEqual(svg.parse_length('120'), 120.0)
+        self.assertEqual(svg.parse_length('120px'), 120.0)
+        self.assertEqual(svg.parse_length(' 12.5 px '), 12.5)
+
+    def test_absolute_units_convert_to_px(self):
+        self.assertAlmostEqual(svg.parse_length('1in'), 96.0)
+        self.assertAlmostEqual(svg.parse_length('72pt'), 96.0)
+        self.assertAlmostEqual(svg.parse_length('2.54cm'), 96.0)
+        self.assertAlmostEqual(svg.parse_length('25.4mm'), 96.0)
+
+    def test_relative_units_are_unresolvable(self):
+        for value in ('100%', '2em', '3ex', '', None, 'auto'):
+            self.assertIsNone(svg.parse_length(value), value)
+
+
+class ParseViewBoxTests(TestCase):
+    def test_separators(self):
+        self.assertEqual(svg.parse_viewbox('0 0 10 20'), (0.0, 0.0, 10.0, 20.0))
+        self.assertEqual(svg.parse_viewbox('0,0,10,20'), (0.0, 0.0, 10.0, 20.0))
+        self.assertEqual(svg.parse_viewbox(' -5 -5  10 , 20 '), (-5.0, -5.0, 10.0, 20.0))
+
+    def test_unusable(self):
+        for value in ('', None, '0 0 10', '0 0 a b', '0 0 0 10', '0 0 10 -3'):
+            self.assertIsNone(svg.parse_viewbox(value), value)
+
+
+class LoadTests(TestCase):
+    def test_size_from_width_and_height(self):
+        image = svg.load(BytesIO(make_svg(width='40', height='20')))
+        self.assertEqual(image.size, (40.0, 20.0))
+
+    def test_size_from_width_and_height_with_units(self):
+        image = svg.load(BytesIO(make_svg(width='1in', height='72pt')))
+        self.assertEqual(image.size, (96.0, 96.0))
+
+    def test_size_falls_back_to_viewbox(self):
+        image = svg.load(BytesIO(make_svg(width='100%', height='100%', viewBox='0 0 30 15')))
+        self.assertEqual(image.size, (30.0, 15.0))
+
+    def test_size_from_viewbox_alone(self):
+        image = svg.load(BytesIO(make_svg(viewBox='0 0 30 15')))
+        self.assertEqual(image.size, (30.0, 15.0))
+
+    def test_missing_size_is_an_error(self):
+        with self.assertRaises(ValueError):
+            svg.load(BytesIO(make_svg()))
+
+    def test_malformed_document_is_an_error(self):
+        with self.assertRaises(ValueError):
+            svg.load(BytesIO(b'<svg><rect></svg>'))
+
+    def test_non_svg_root_is_an_error(self):
+        with self.assertRaises(ValueError):
+            svg.load(BytesIO(b'<html width="10" height="10"></html>'))
+
+    def test_entity_declarations_are_rejected(self):
+        """``xml.etree`` expands internal entities, so "billion laughs" is refused."""
+        bomb = (
+            b'<!DOCTYPE svg [<!ENTITY a "aaaaaaaaaa">'
+            b'<!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">]>'
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+            b'<desc>&b;</desc></svg>'
+        )
+        with self.assertRaises(ValueError):
+            svg.load(BytesIO(bomb))
+
+    def test_external_doctype_is_accepted(self):
+        """The DTD reference that many authoring tools emit is harmless."""
+        document = (
+            b'<?xml version="1.0"?>'
+            b'<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" '
+            b'"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">'
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="50" height="25"/>'
+        )
+        self.assertEqual(svg.load(BytesIO(document)).size, (50.0, 25.0))
+
+    def test_load_rewinds_the_stream(self):
+        handle = BytesIO(make_svg(width='40', height='20'))
+        handle.read()
+        self.assertEqual(svg.load(handle).size, (40.0, 20.0))
+
+    def test_get_dimensions(self):
+        self.assertEqual(
+            svg.get_dimensions(BytesIO(make_svg(width='40', height='20'))),
+            (40.0, 20.0),
+        )
+
+
+class ResizeAndCropTests(TestCase):
+    def serialize(self, image):
+        destination = StringIO()
+        image.save(destination)
+        return ET.fromstring(destination.getvalue())
+
+    def test_resize_sets_width_height_and_viewbox(self):
+        image = svg.load(BytesIO(make_svg(width='40', height='20', viewBox='0 0 40 20')))
+        resized = image.resize((20, 10))
+        self.assertEqual(resized.size, (20.0, 10.0))
+        root = self.serialize(resized)
+        self.assertEqual(root.get('width'), '20')
+        self.assertEqual(root.get('height'), '10')
+        self.assertEqual(root.get('viewBox'), '0 0 40 20')
+
+    def test_resize_adds_the_implied_viewbox(self):
+        """
+        Without a viewBox, changing width and height would only grow the canvas
+        and leave the drawing at its original scale.
+        """
+        image = svg.load(BytesIO(make_svg(width='40', height='20')))
+        root = self.serialize(image.resize((20, 10)))
+        self.assertEqual(root.get('viewBox'), '0 0 40 20')
+
+    def test_resize_keeps_the_contents(self):
+        image = svg.load(BytesIO(make_svg(width='40', height='20')))
+        root = self.serialize(image.resize((20, 10)))
+        self.assertEqual(len(root), 1)
+        self.assertEqual(root[0].tag, '{http://www.w3.org/2000/svg}rect')
+
+    def test_resize_does_not_touch_the_original(self):
+        image = svg.load(BytesIO(make_svg(width='40', height='20')))
+        image.resize((20, 10))
+        self.assertEqual(image.size, (40.0, 20.0))
+
+    def test_crop_maps_pixels_onto_user_units(self):
+        # 200x100 px showing a 20x10 user unit viewBox: 1 user unit = 10 px.
+        image = svg.load(BytesIO(make_svg(width='200', height='100', viewBox='0 0 20 10')))
+        cropped = image.crop((50, 20, 150, 80))
+        self.assertEqual(cropped.size, (100.0, 60.0))
+        root = self.serialize(cropped)
+        self.assertEqual(root.get('width'), '100')
+        self.assertEqual(root.get('height'), '60')
+        self.assertEqual(root.get('viewBox'), '5 2 10 6')
+
+    def test_crop_respects_the_viewbox_origin(self):
+        image = svg.load(BytesIO(make_svg(width='20', height='10', viewBox='-10 -5 20 10')))
+        root = self.serialize(image.crop((0, 0, 10, 5)))
+        self.assertEqual(root.get('viewBox'), '-10 -5 10 5')
+
+    def test_crop_without_a_box_copies(self):
+        image = svg.load(BytesIO(make_svg(width='40', height='20')))
+        self.assertEqual(image.crop().size, (40.0, 20.0))
+
+    def test_save_keeps_svg_as_the_default_namespace(self):
+        image = svg.load(BytesIO(make_svg(width='40', height='20')))
+        destination = StringIO()
+        image.save(destination, format='SVG')
+        self.assertIn('xmlns="http://www.w3.org/2000/svg"', destination.getvalue())
+        self.assertNotIn('ns0:', destination.getvalue())
+
+    def test_save_rejects_other_formats(self):
+        image = svg.load(BytesIO(make_svg(width='40', height='20')))
+        with self.assertRaises(ValueError):
+            image.save(StringIO(), format='PNG')
+
+
+class SvgThumbnailTests(TestCase):
+    """SVG thumbnails are generated without svglib/reportlab being involved."""
+
+    def create_image(self, content=None, name='vector.svg'):
+        return Image.objects.create(
+            file=SimpleUploadedFile(
+                name=name,
+                content=content if content is not None else make_svg(
+                    width='400', height='200', viewBox='0 0 400 200'),
+                content_type='image/svg+xml',
+            ),
+            original_filename=name,
+        )
+
+    def read(self, thumbnail):
+        """Read a thumbnail back from storage (the returned file is exhausted)."""
+        with thumbnail.storage.open(thumbnail.name) as handle:
+            return handle.read()
+
+    def test_dimensions_are_read_on_save(self):
+        image = self.create_image()
+        self.assertEqual((image.width, image.height), (400.0, 200.0))
+
+    def test_thumbnail_is_a_scaled_svg(self):
+        image = self.create_image()
+        thumbnail = get_thumbnailer(image).get_thumbnail({'size': (100, 100), 'upscale': False})
+
+        self.assertTrue(thumbnail.name.endswith('.svg'))
+        root = ET.fromstring(self.read(thumbnail))
+        self.assertEqual(root.tag, '{http://www.w3.org/2000/svg}svg')
+        # 400x200 scaled to fit into 100x100 keeps the aspect ratio.
+        self.assertEqual(root.get('width'), '100')
+        self.assertEqual(root.get('height'), '50')
+        self.assertEqual(root.get('viewBox'), '0 0 400 200')
+        # The vector contents survive untouched.
+        self.assertEqual(root[0].tag, '{http://www.w3.org/2000/svg}rect')
+
+    def test_cropped_thumbnail_narrows_the_viewbox(self):
+        image = self.create_image()
+        thumbnail = get_thumbnailer(image).get_thumbnail({'size': (100, 100), 'crop': True})
+
+        root = ET.fromstring(self.read(thumbnail))
+        self.assertEqual(root.get('width'), '100')
+        self.assertEqual(root.get('height'), '100')
+        # Cropping to a square takes the centre 200 user units of the 400 wide box.
+        self.assertEqual(root.get('viewBox'), '100 0 200 200')
+
+    def test_thumbnail_reports_its_dimensions(self):
+        image = self.create_image()
+        thumbnailer = get_thumbnailer(image)
+        options = {'size': (100, 100), 'upscale': False}
+        thumbnailer.get_thumbnail(options)
+
+        # A second lookup returns the thumbnail from storage, which has to read
+        # its dimensions back from the saved document.
+        existing = thumbnailer.get_existing_thumbnail(options)
+        self.assertIsNotNone(existing)
+        self.assertEqual((existing.width, existing.height), (100.0, 50.0))
+
+    def test_unreadable_svg_leaves_dimensions_unset(self):
+        image = self.create_image(content=b'<svg><rect></svg>', name='broken.svg')
+        self.assertEqual((image.width, image.height), (0.0, 0.0))
+
+
+class OptionalDependencyTests(TestCase):
+    """
+    The SVG renderer is an optional dependency (``django-filer[svg]``).
+
+    Importing it at module level would make filer refuse to start without it, so
+    it may only be imported from inside a function.
+    """
+
+    OPTIONAL = ('svglib', 'reportlab', 'easy_thumbnails.VIL')
+
+    def import_time_modules(self, tree):
+        """Yield the modules a source tree imports when it is imported."""
+        def walk(node):
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    # Imports inside a function only run when it is called.
+                    continue
+                if isinstance(child, ast.Import):
+                    yield from (alias.name for alias in child.names)
+                elif isinstance(child, ast.ImportFrom) and child.level == 0:
+                    yield child.module or ''
+                yield from walk(child)
+
+        return walk(tree)
+
+    def test_no_module_level_import_of_the_svg_renderer(self):
+        root = pathlib.Path(__file__).resolve().parent.parent / 'filer'
+        offenders = []
+        for source in sorted(root.rglob('*.py')):
+            tree = ast.parse(source.read_text(), filename=str(source))
+            for module in self.import_time_modules(tree):
+                if module.split('.')[0] in ('svglib', 'reportlab') or module.startswith('easy_thumbnails.VIL'):
+                    offenders.append(f'{source.relative_to(root.parent)}: {module}')
+        self.assertEqual(offenders, [])

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -88,12 +88,29 @@ class LoadTests(TestCase):
         image = svg.load(BytesIO(make_svg(width='100%', height='100%', viewBox='0 0 30 15')))
         self.assertEqual(image.size, (30.0, 15.0))
 
+    def test_stated_width_is_kept_and_height_follows_the_viewbox_ratio(self):
+        """
+        A viewBox states an aspect ratio as well as a size, so a width the
+        markup does give must not be thrown away for the viewBox's own width.
+        """
+        image = svg.load(BytesIO(make_svg(width='200', viewBox='0 0 100 50')))
+        self.assertEqual(image.size, (200.0, 100.0))
+
+    def test_stated_height_is_kept_and_width_follows_the_viewbox_ratio(self):
+        image = svg.load(BytesIO(make_svg(height='200', viewBox='0 0 100 50')))
+        self.assertEqual(image.size, (400.0, 200.0))
+
+    def test_both_stated_dimensions_win_over_the_viewbox(self):
+        image = svg.load(BytesIO(make_svg(width='200', height='33', viewBox='0 0 100 50')))
+        self.assertEqual(image.size, (200.0, 33.0))
+
     def test_size_from_viewbox_alone(self):
         image = svg.load(BytesIO(make_svg(viewBox='0 0 30 15')))
         self.assertEqual(image.size, (30.0, 15.0))
 
-    def test_missing_size_is_an_error(self):
-        with self.assertRaises(ValueError):
+    def test_missing_size_is_unresolvable(self):
+        """Only a renderer can size a document that states no size at all."""
+        with self.assertRaises(svg.UnresolvableSize):
             svg.load(BytesIO(make_svg()))
 
     def test_malformed_document_is_an_error(self):
@@ -160,13 +177,16 @@ class LoadTests(TestCase):
         self.assertEqual(image.size, (8.0, 4.0))
 
     def test_non_positive_size_without_a_viewbox_is_an_error(self):
+        """A stated but impossible size is wrong markup, not a missing size."""
         for attrs in ({'width': '0', 'height': '0'}, {'width': '-10', 'height': '-5'}):
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ValueError) as caught:
                 svg.load(BytesIO(make_svg(**attrs)))
+            self.assertNotIsInstance(caught.exception, svg.UnresolvableSize)
 
     def test_infinite_size_is_an_error(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as caught:
             svg.load(BytesIO(make_svg(width='1e999', height='10')))
+        self.assertNotIsInstance(caught.exception, svg.UnresolvableSize)
 
     def test_external_doctype_is_accepted(self):
         """The DTD reference that many authoring tools emit is harmless."""
@@ -441,3 +461,73 @@ class ImageSizeGuardTests(TestCase):
         with self.assertRaises(ValidationError) as caught:
             image.clean()
         self.assertEqual(caught.exception.code, 'image_size')
+
+
+@unittest.skipUnless(VIL.is_available(), "requires the django-filer[svg] extra")
+class RendererFallbackTests(TestCase):
+    """
+    Installing the optional renderer must never weaken a check.
+
+    ``open_image()`` falls back to it for one failure only - a document whose
+    size cannot be worked out from the markup. Anything filer rejects has to
+    stay rejected, or the renderer would quietly launder documents past the
+    entity, root-element and geometry checks.
+    """
+
+    def open(self, content):
+        return svg.open_image(
+            SimpleUploadedFile('doc.svg', content, content_type='image/svg+xml'))
+
+    def test_entity_declarations_are_not_laundered(self):
+        with self.assertRaises(ValueError):
+            self.open(
+                b'<!DOCTYPE svg [<!ENTITY a "aaaaaaaaaa">]>'
+                b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+                b'<desc>&a;</desc></svg>')
+
+    def test_a_non_svg_root_is_not_laundered(self):
+        with self.assertRaises(ValueError):
+            self.open(b'<html width="10" height="10"></html>')
+
+    def test_malformed_markup_is_not_laundered(self):
+        with self.assertRaises(ValueError):
+            self.open(b'<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10">'
+                      b'<rect></svg>')
+
+    def test_impossible_dimensions_are_not_laundered(self):
+        for attrs in (b'width="-10" height="10"', b'width="0" height="10"',
+                      b'width="1e999" height="10"'):
+            with self.assertRaises(ValueError):
+                self.open(b'<svg xmlns="http://www.w3.org/2000/svg" ' + attrs + b'/>')
+
+    def test_an_unresolvable_size_is_what_the_renderer_is_for(self):
+        image = self.open(
+            b'<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">'
+            b'<rect width="5" height="5"/></svg>')
+        self.assertIsNotNone(image)
+
+
+@unittest.skipIf(VIL.is_available(), "covers a default install, without the extra")
+class WithoutRendererTests(TestCase):
+    """
+    What a plain ``pip install django-filer`` makes of a document only the
+    optional renderer could measure. The mirror image of
+    :class:`RendererFallbackTests`, so that both installations are covered.
+    """
+
+    RELATIVE = (b'<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">'
+                b'<rect width="5" height="5"/></svg>')
+
+    def test_open_image_reports_the_size_as_unresolvable(self):
+        with self.assertRaises(svg.UnresolvableSize):
+            svg.open_image(SimpleUploadedFile(
+                'relative.svg', self.RELATIVE, content_type='image/svg+xml'))
+
+    def test_dimensions_stay_unset(self):
+        """The admin falls back to a generic icon rather than failing."""
+        image = Image.objects.create(
+            file=SimpleUploadedFile(
+                'relative.svg', self.RELATIVE, content_type='image/svg+xml'),
+            original_filename='relative.svg',
+        )
+        self.assertEqual((image.width, image.height), (0.0, 0.0))

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -6,15 +6,17 @@ import unittest
 import xml.etree.ElementTree as ET
 from io import BytesIO, StringIO
 
+from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
 from easy_thumbnails import VIL
-from easy_thumbnails.exceptions import EasyThumbnailsError
+from easy_thumbnails.exceptions import EasyThumbnailsError, InvalidImageFormatError
 from easy_thumbnails.files import get_thumbnailer
 
 from filer.settings import FILER_IMAGE_MODEL
 from filer.utils import svg
+from filer.utils.filer_easy_thumbnails import svg_source_generator
 from filer.utils.loader import load_model
 
 
@@ -238,6 +240,18 @@ class ResizeAndCropTests(TestCase):
         root = self.serialize(image.crop((0, 0, 10, 5)))
         self.assertEqual(root.get('viewBox'), '-10 -5 10 5')
 
+    def test_crop_with_a_degenerate_box_copies(self):
+        """A box with no area leaves the image at its current geometry."""
+        image = svg.load(BytesIO(make_svg(width='40', height='20')))
+        for box in ((10, 10, 10, 10), (30, 0, 10, 20)):
+            cropped = image.crop(box)
+            self.assertEqual(cropped.size, (40.0, 20.0), box)
+
+    def test_filter_is_a_no_op(self):
+        """The ``detail`` and ``sharpen`` processors do not apply to vectors."""
+        image = svg.load(BytesIO(make_svg(width='40', height='20')))
+        self.assertIs(image.filter('anything'), image)
+
     def test_crop_without_a_box_copies(self):
         image = svg.load(BytesIO(make_svg(width='40', height='20')))
         self.assertEqual(image.crop().size, (40.0, 20.0))
@@ -341,6 +355,26 @@ class SvgThumbnailTests(TestCase):
         self.assertEqual(ET.fromstring(self.read(thumbnail)).tag,
                          '{http://www.w3.org/2000/svg}svg')
 
+    def test_source_generator_without_a_source(self):
+        """easy-thumbnails passes ``None`` when it cannot open the file."""
+        self.assertIsNone(svg_source_generator(None))
+
+    def test_unopenable_svg_reports_an_invalid_image_format(self):
+        """
+        The ``{% thumbnail %}`` tag asks the source generators for silence, so a
+        file named ``.svg`` that is not SVG surfaces here rather than earlier.
+        """
+        image = self.create_image(content=b'this is not markup', name='notreally.svg')
+        with self.assertRaises(InvalidImageFormatError):
+            get_thumbnailer(image).get_thumbnail(
+                {'size': (100, 100)}, silent_template_exception=True)
+
+    def test_unparseable_thumbnail_size_is_rejected(self):
+        """A size with no numbers in it leaves nothing to scale to."""
+        thumbnailer = get_thumbnailer(self.create_image())
+        with self.assertRaises(EasyThumbnailsError):
+            thumbnailer.get_thumbnail({'size': ('wide', None)})
+
     def test_unreadable_svg_leaves_dimensions_unset(self):
         image = self.create_image(content=b'<svg><rect></svg>', name='broken.svg')
         self.assertEqual((image.width, image.height), (0.0, 0.0))
@@ -380,3 +414,30 @@ class OptionalDependencyTests(TestCase):
                 if module.split('.')[0] in ('svglib', 'reportlab') or module.startswith('easy_thumbnails.VIL'):
                     offenders.append(f'{source.relative_to(root.parent)}: {module}')
         self.assertEqual(offenders, [])
+
+
+class ImageSizeGuardTests(TestCase):
+    """
+    ``BaseImage.clean()`` refuses images whose dimensions cannot be read: for a
+    raster image that is the signature of a decompression bomb, since Pillow
+    reports no size for one. A vector image has no pixel count at all, so the
+    guard must not catch it.
+    """
+
+    def unmeasurable_image(self, name, mime_type):
+        image = Image(
+            file=SimpleUploadedFile(name=name, content=b'...', content_type=mime_type),
+            original_filename=name,
+            mime_type=mime_type,
+        )
+        image._width, image._height = None, None
+        return image
+
+    def test_vector_image_without_dimensions_is_allowed(self):
+        self.unmeasurable_image('vector.svg', 'image/svg+xml').clean()
+
+    def test_raster_image_without_dimensions_is_rejected(self):
+        image = self.unmeasurable_image('photo.jpg', 'image/jpeg')
+        with self.assertRaises(ValidationError) as caught:
+            image.clean()
+        self.assertEqual(caught.exception.code, 'image_size')

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -117,6 +117,29 @@ class LoadTests(TestCase):
         with self.assertRaises(ValueError):
             svg.load(BytesIO(b'<svg><rect></svg>'))
 
+    def test_deeply_nested_documents_are_rejected(self):
+        """
+        ``ElementTree`` serializes recursively, one stack frame per level, so a
+        few kilobytes of nested groups would otherwise raise ``RecursionError``
+        while a thumbnail is written - inside a request, where much of the stack
+        is already spent.
+        """
+        def nested(depth):
+            return (b'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">'
+                    + b'<g>' * depth + b'</g>' * depth + b'</svg>')
+
+        # One under the limit, counting the root element, still thumbnails.
+        image = svg.load(BytesIO(nested(svg.MAX_NESTING_DEPTH - 1)))
+        destination = StringIO()
+        image.resize((50, 50)).save(destination)
+        self.assertTrue(destination.getvalue())
+
+        with self.assertRaises(ValueError) as caught:
+            svg.load(BytesIO(nested(svg.MAX_NESTING_DEPTH)))
+        self.assertNotIsInstance(caught.exception, svg.UnresolvableSize)
+        with self.assertRaises(ValueError):
+            svg.load(BytesIO(nested(2000)))
+
     def test_non_svg_root_is_an_error(self):
         with self.assertRaises(ValueError):
             svg.load(BytesIO(b'<html width="10" height="10"></html>'))

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -10,8 +10,12 @@ from django.test import TestCase
 
 from easy_thumbnails.files import get_thumbnailer
 
-from filer.models.imagemodels import Image
+from filer.settings import FILER_IMAGE_MODEL
 from filer.utils import svg
+from filer.utils.loader import load_model
+
+
+Image = load_model(FILER_IMAGE_MODEL)
 
 
 SVG_TEMPLATE = (

--- a/tests/test_svg.py
+++ b/tests/test_svg.py
@@ -172,9 +172,17 @@ class LoadTests(TestCase):
         with self.assertRaises(ValueError):
             svg.load(BytesIO(bomb))
 
-    def test_non_positive_size_falls_back_to_the_viewbox(self):
-        image = svg.load(BytesIO(make_svg(width='0', height='0', viewBox='0 0 8 4')))
-        self.assertEqual(image.size, (8.0, 4.0))
+    def test_the_viewbox_does_not_rescue_an_impossible_size(self):
+        """
+        Inference fills in what the markup leaves out; it must not overwrite
+        what the markup gets wrong.
+        """
+        for attrs in ({'width': '0', 'height': '0'},
+                      {'width': '-10', 'height': '20'},
+                      {'width': '1e999', 'height': '20'}):
+            with self.assertRaises(ValueError) as caught:
+                svg.load(BytesIO(make_svg(viewBox='0 0 100 50', **attrs)))
+            self.assertNotIsInstance(caught.exception, svg.UnresolvableSize)
 
     def test_non_positive_size_without_a_viewbox_is_an_error(self):
         """A stated but impossible size is wrong markup, not a missing size."""
@@ -438,10 +446,13 @@ class OptionalDependencyTests(TestCase):
 
 class ImageSizeGuardTests(TestCase):
     """
-    ``BaseImage.clean()`` refuses images whose dimensions cannot be read: for a
-    raster image that is the signature of a decompression bomb, since Pillow
-    reports no size for one. A vector image has no pixel count at all, so the
-    guard must not catch it.
+    ``BaseImage.clean()`` measures every image it can against
+    ``FILER_MAX_IMAGE_PIXELS``, vector images included.
+
+    Only images whose dimensions cannot be read are treated by type: for a
+    raster image that is itself the signature of a decompression bomb, since
+    Pillow reports no size for one, while a vector image has no pixel count to
+    compare against.
     """
 
     def unmeasurable_image(self, name, mime_type):
@@ -455,6 +466,14 @@ class ImageSizeGuardTests(TestCase):
 
     def test_vector_image_without_dimensions_is_allowed(self):
         self.unmeasurable_image('vector.svg', 'image/svg+xml').clean()
+
+    def test_oversized_vector_image_is_rejected(self):
+        """An SVG that does state its size is measured like any other image."""
+        image = self.unmeasurable_image('huge.svg', 'image/svg+xml')
+        image._width, image._height = 30000, 30000
+        with self.assertRaises(ValidationError) as caught:
+            image.clean()
+        self.assertEqual(caught.exception.code, 'image_size')
 
     def test_raster_image_without_dimensions_is_rejected(self):
         image = self.unmeasurable_image('photo.jpg', 'image/jpeg')
@@ -499,6 +518,16 @@ class RendererFallbackTests(TestCase):
                       b'width="1e999" height="10"'):
             with self.assertRaises(ValueError):
                 self.open(b'<svg xmlns="http://www.w3.org/2000/svg" ' + attrs + b'/>')
+
+    def test_a_partial_renderer_size_is_not_accepted(self):
+        """
+        The renderer answers ``(200, 0)`` for a document stating only a width,
+        and ``(0, 0)`` for one stating nothing. Neither is a size.
+        """
+        for attrs in (b'width="200"', b''):
+            with self.assertRaises(svg.UnresolvableSize):
+                self.open(b'<svg xmlns="http://www.w3.org/2000/svg" ' + attrs +
+                          b'><rect width="5" height="5"/></svg>')
 
     def test_an_unresolvable_size_is_what_the_renderer_is_for(self):
         image = self.open(


### PR DESCRIPTION
## Summary by Sourcery

Simplify SVG support by handling dimensions and thumbnails natively while retaining the optional renderer only as a fallback.

New Features:
- Add dependency-free SVG dimension parsing and vector-preserving thumbnail generation, with optional renderer fallback for SVGs whose size cannot be inferred from markup.

Bug Fixes:
- Preserve image file stream positions after metadata inspection and allow unmeasurable SVGs to bypass raster decompression-size validation while still enforcing stated size limits.

Enhancements:
- Strengthen SVG validation against malformed geometry, entity declarations, invalid roots, and excessive nesting.

Build:
- Make the SVG renderer optional and expose it through the django-filer[svg] extra instead of requiring it by default.

CI:
- Add a CI job that runs the test suite without svglib and reportlab to verify plain installations.

Documentation:
- Document SVG dependency options, supported handling, configuration, and upgrade considerations.

Tests:
- Add comprehensive coverage for SVG parsing, sizing, resizing, cropping, thumbnail persistence, security validation, optional-renderer fallback, and no-renderer installations.

## Related resources

<!--
Add here links to existing issues or conversation from GitHub
or any other resource.
-->

* fixes #1547 
* #...

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [ ] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-filer/blob/master/docs/development.rst#contributing) and I have joined #pr-reviews on
[Discord](https://www.django-cms.org/dicord) to find a “pr review buddy” who is going to review my pull request.